### PR TITLE
Revert PlatformTarget to AnyCPU

### DIFF
--- a/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
+++ b/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
@@ -29,7 +29,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
+++ b/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
@@ -29,7 +29,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
+++ b/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
@@ -29,7 +29,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Visual studio is x86 and can not show custom user controls if these controls have not been compiled in x86. This is an issue for the Animation groups, in which I have included a custom user control.