### PR TITLE
Update Unity exporter to export metal roughness texture map.

### DIFF
--- a/Unity 5/EditorToolkit/Assets/Babylon/Entities/BabylonPBRMaterial.cs
+++ b/Unity 5/EditorToolkit/Assets/Babylon/Entities/BabylonPBRMaterial.cs
@@ -95,6 +95,9 @@ namespace BabylonExport.Entities
         public bool useRoughnessFromMetallicTextureGreen { get; set; }
 
         [DataMember]
+        public bool useMetallnessFromMetallicTextureBlue { get; set; }
+
+        [DataMember]
         public bool useAlphaFromAlbedoTexture { get; set; }
 
         [DataMember]
@@ -133,6 +136,9 @@ namespace BabylonExport.Entities
         [DataMember]
         public int maxSimultaneousLights { get; set; }
 
+        [DataMember]
+        public int sideOrientation { get; set; }
+
         public BabylonPBRMaterial() : base()
         {
             SetCustomType("BABYLON.PBRMaterial");
@@ -153,8 +159,12 @@ namespace BabylonExport.Entities
             // Default Null Metallic Workflow
             metallic = null;
             roughness = null;
-            useRoughnessFromMetallicTextureAlpha = true;
-            useRoughnessFromMetallicTextureGreen = false;
+            useRoughnessFromMetallicTextureAlpha = false;
+            useRoughnessFromMetallicTextureGreen = true;
+
+            useMetallnessFromMetallicTextureBlue = true;
+
+            sideOrientation = 1;
 
             microSurface = 0.9f;
             useMicroSurfaceFromReflectivityMapAplha = false;

--- a/Unity 5/EditorToolkit/Assets/Babylon/Scripts/ExporterMetadata.cs
+++ b/Unity 5/EditorToolkit/Assets/Babylon/Scripts/ExporterMetadata.cs
@@ -1124,8 +1124,9 @@ namespace UnityEditor
 
             this.metallic = null;
             this.roughness = null;
-            this.useRoughnessFromMetallicTextureAlpha = true;
-            this.useRoughnessFromMetallicTextureGreen = false;
+            this.useRoughnessFromMetallicTextureAlpha = false;
+            this.useRoughnessFromMetallicTextureGreen = true;
+            this.useMetallnessFromMetallicTextureBlue = true;
 
             this.microSurface = 0.9f;
             this.useMicroSurfaceFromReflectivityMapAplha = false;

--- a/Unity 5/EditorToolkit/Assets/Babylon/Scripts/ExporterWindow.cs
+++ b/Unity 5/EditorToolkit/Assets/Babylon/Scripts/ExporterWindow.cs
@@ -41,7 +41,7 @@ namespace Unity3D2Babylon
         bool showPreview = false;
         bool showCompiler = false;
         int buildResult = 0;
-        string defaultProjectFolder = String.Empty;
+        public string defaultProjectFolder = String.Empty;
         string guiProjectFolder = String.Empty;
         public bool previewThread = false;
 

--- a/Unity 5/EditorToolkit/Assets/Babylon/Scripts/SceneBuilder.Lights.cs
+++ b/Unity 5/EditorToolkit/Assets/Babylon/Scripts/SceneBuilder.Lights.cs
@@ -49,22 +49,19 @@ namespace Unity3D2Babylon
                 {
                     if (gameObject.layer != ExporterWindow.PrefabIndex)
                     {
-                        if (!gameObject.IsLightapStatic()) {
-                            var shadowmap = gameObject.GetComponent<ShadowMap>();
-                            if (shadowmap != null && shadowmap.runtimeShadows == BabylonEnabled.Enabled)
+                        if (!gameObject.IsLightapStatic())
+                        {
+                            var renderer = gameObject.GetComponent<Renderer>();
+                            var meshFilter = gameObject.GetComponent<MeshFilter>();
+                            if (meshFilter != null && renderer != null && renderer.shadowCastingMode != ShadowCastingMode.Off)
                             {
-                                var renderer = gameObject.GetComponent<Renderer>();
-                                var meshFilter = gameObject.GetComponent<MeshFilter>();
-                                if (meshFilter != null && renderer != null && renderer.shadowCastingMode != ShadowCastingMode.Off)
-                                {
-                                    renderList.Add(GetID(gameObject));
-                                    continue;
-                                }
-                                var skinnedMesh = gameObject.GetComponent<SkinnedMeshRenderer>();
-                                if (skinnedMesh != null && renderer != null && renderer.shadowCastingMode != ShadowCastingMode.Off)
-                                {
-                                    renderList.Add(GetID(gameObject));
-                                }
+                                renderList.Add(GetID(gameObject));
+                                continue;
+                            }
+                            var skinnedMesh = gameObject.GetComponent<SkinnedMeshRenderer>();
+                            if (skinnedMesh != null && renderer != null && renderer.shadowCastingMode != ShadowCastingMode.Off)
+                            {
+                                renderList.Add(GetID(gameObject));
                             }
                         }
                     }
@@ -80,7 +77,7 @@ namespace Unity3D2Babylon
         private void ConvertUnityLightToBabylon(Light light, GameObject gameObject, float progress, ref UnityMetaData metaData, ref List<UnityFlareSystem> lensFlares, ref string componentTags)
         {
             // Note: No Inactive Or Full Baking Lights Exported
-			if (light.isActiveAndEnabled == false || light.type == LightType.Area || light.lightmapBakeType == LightmapBakeType.Baked) return;
+            if (light.isActiveAndEnabled == false || light.type == LightType.Area || light.lightmapBakeType == LightmapBakeType.Baked) return;
 
             ExporterWindow.ReportProgress(progress, "Exporting light: " + light.name);
             BabylonLight babylonLight = (light.type == LightType.Directional) ? new BabylonDirectionalLight() : new BabylonLight();
@@ -114,11 +111,11 @@ namespace Unity3D2Babylon
             transformedDirection[1] += defaultRotationOffset.y;
             transformedDirection[2] += defaultRotationOffset.z;
             babylonLight.direction = transformedDirection.ToFloat();
-            
+
             babylonLight.diffuse = light.color.ToFloat();
 
             float defaultIntenistyFactor = (SceneController != null) ? SceneController.lightingOptions.intensityScale : ExporterWindow.DefaultIntensityScale;
-            babylonLight.intensity = light.intensity *  defaultIntenistyFactor;
+            babylonLight.intensity = light.intensity * defaultIntenistyFactor;
 
             babylonLight.angle = light.spotAngle * (float)Math.PI / 180;
             babylonLight.exponent = 1.0f;


### PR DESCRIPTION
- Add additional properties related to metallic pbr material
- Remove the need to check for ShadowMap component because Unity meshes have a shadowCastingMode that serve the same purpose
- Add support to export Metallic texture map. B channel contains metallic, G channel contains roughness.