### PR TITLE
support for extensions

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.cs
@@ -46,6 +46,10 @@ namespace Max2Babylon
                 // no minVersion
             };
 
+            // Extensions
+            gltf.extensionsUsed = new List<string>();
+            gltf.extensionsRequired = new List<string>();
+
             // Scene
             gltf.scene = 0;
 

--- a/SharedProjects/GltfExport.Entities/GLTF.cs
+++ b/SharedProjects/GltfExport.Entities/GLTF.cs
@@ -11,6 +11,12 @@ namespace GLTFExport.Entities
         public GLTFAsset asset { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public List<string> extensionsUsed { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<string> extensionsRequired { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public int? scene { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/SharedProjects/GltfExport.Entities/GLTFExtensions.cs
+++ b/SharedProjects/GltfExport.Entities/GLTFExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace GLTFExport.Entities
+{
+    [CollectionDataContract]
+    public class GLTFExtensions : Dictionary<string, object>
+    {
+
+    }
+}

--- a/SharedProjects/GltfExport.Entities/GLTFProperty.cs
+++ b/SharedProjects/GltfExport.Entities/GLTFProperty.cs
@@ -6,7 +6,7 @@ namespace GLTFExport.Entities
     public class GLTFProperty
     {
         [DataMember(EmitDefaultValue = false)]
-        public object extensions { get; set; }
+        public GLTFExtensions extensions { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public object extras { get; set; }

--- a/SharedProjects/GltfExport.Entities/GltfExport.Entities.projitems
+++ b/SharedProjects/GltfExport.Entities/GltfExport.Entities.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GLTFChannel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GLTFChannelTarget.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GLTFChildRootProperty.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GLTFExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GLTFImage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GLTFIndexedChildRootProperty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GLTFMaterial.cs" />


### PR DESCRIPTION
Our custom material uses some extensions, so we need to be able to serialize them. These changes facilitate that.

Note: untested, because I only have max 2016 and I can't export with it in the current state.