### PR TITLE
allow overwriting existing bitmaps when saving bitmaps

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Texture.cs
@@ -45,7 +45,10 @@ namespace Max2Babylon
                     var absolutePath = Path.Combine(gltf.OutputFolder, name);
                     var imageFormat = extension == ".jpg" ? System.Drawing.Imaging.ImageFormat.Jpeg : System.Drawing.Imaging.ImageFormat.Png;
                     RaiseMessage($"GLTFExporter.Texture | write image '{name}' to '{absolutePath}'", 3);
-                    bitmap.Save(absolutePath, imageFormat);
+                    using (FileStream fs = File.Open(absolutePath, FileMode.Create))
+                    {
+                        bitmap.Save(fs, imageFormat);
+                    }
                 }
 
                 return extension.Substring(1); // remove the dot

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -159,7 +159,10 @@ namespace Max2Babylon
                 {
                     var absolutePath = Path.Combine(babylonScene.OutputPath, babylonTexture.name);
                     RaiseMessage($"Texture | write image '{babylonTexture.name}'", 3);
-                    baseColorAlphaBitmap.Save(absolutePath, System.Drawing.Imaging.ImageFormat.Png); // Explicit image format even though png is default
+                    using (FileStream fs = File.Open(absolutePath, FileMode.Create))
+                    {
+                        baseColorAlphaBitmap.Save(fs, System.Drawing.Imaging.ImageFormat.Png); // Explicit image format even though png is default
+                    }
                 }
                 else
                 {
@@ -259,7 +262,10 @@ namespace Max2Babylon
                 {
                     var absolutePath = Path.Combine(babylonScene.OutputPath, babylonTexture.name);
                     RaiseMessage($"Texture | write image '{babylonTexture.name}'", 3);
-                    metallicRoughnessBitmap.Save(absolutePath, System.Drawing.Imaging.ImageFormat.Jpeg);
+                    using (FileStream fs = File.Open(absolutePath, FileMode.Create))
+                    {
+                        metallicRoughnessBitmap.Save(fs, System.Drawing.Imaging.ImageFormat.Jpeg);
+                    }
                 }
                 else
                 {
@@ -850,7 +856,10 @@ namespace Max2Babylon
                     try
                     {
                         bitmap = GDImageLibrary._DDS.LoadImage(sourcePath);
-                        bitmap.Save(destPath, System.Drawing.Imaging.ImageFormat.Png);
+                        using (FileStream fs = File.Open(destPath, FileMode.Create))
+                        {
+                            bitmap.Save(fs, System.Drawing.Imaging.ImageFormat.Png);
+                        }
                     }
                     catch (Exception e)
                     {
@@ -862,7 +871,10 @@ namespace Max2Babylon
                     try
                     {
                         bitmap = Paloma.TargaImage.LoadTargaImage(sourcePath);
-                        bitmap.Save(destPath, System.Drawing.Imaging.ImageFormat.Png);
+                        using (FileStream fs = File.Open(destPath, FileMode.Create))
+                        {
+                            bitmap.Save(fs, System.Drawing.Imaging.ImageFormat.Png);
+                        }
                     }
                     catch (Exception e)
                     {
@@ -871,13 +883,19 @@ namespace Max2Babylon
                     break;
                 case "bmp":
                     bitmap = new Bitmap(sourcePath);
-                    bitmap.Save(destPath, System.Drawing.Imaging.ImageFormat.Jpeg); // no alpha
+                    using (FileStream fs = File.Open(destPath, FileMode.Create))
+                    {
+                        bitmap.Save(fs, System.Drawing.Imaging.ImageFormat.Jpeg); // no alpha
+                    }
                     break;
                 case "tif":
                 case "tiff":
                 case "gif":
                     bitmap = new Bitmap(sourcePath);
-                    bitmap.Save(destPath, System.Drawing.Imaging.ImageFormat.Png);
+                    using (FileStream fs = File.Open(destPath, FileMode.Create))
+                    {
+                        bitmap.Save(fs, System.Drawing.Imaging.ImageFormat.Png);
+                    }
                     break;
                 case "jpeg":
                 case "png":


### PR DESCRIPTION
this was the default for every other file open I could find in the project (and is quite convenient)

As with the other pull request, could not test with the latest version (I've tested with an older version and it worked fine)