### PR TITLE
Safely close exporter

### DIFF
--- a/Maya/Forms/ExporterForm.cs
+++ b/Maya/Forms/ExporterForm.cs
@@ -197,6 +197,23 @@ namespace Maya2Babylon.Forms
             return newNode;
         }
 
+        internal Func<bool> closingByUser;
+        internal Func<bool> closingByShutDown;
+        //internal Func<bool> closingByCrash;
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            base.OnFormClosing(e);
+
+            // closing the form with (x)
+            e.Cancel = true;
+
+            // if windows is shutting down
+            if (e.CloseReason == CloseReason.WindowsShutDown) this.closingByShutDown();
+
+            // if user is closing
+            if (e.CloseReason == CloseReason.UserClosing) this.closingByUser();
+        }
+
         private void ExporterForm_FormClosed(object sender, FormClosedEventArgs e)
         {
             if (exporter != null)

--- a/Maya/MayaPlugin.cs
+++ b/Maya/MayaPlugin.cs
@@ -28,10 +28,13 @@ namespace Maya2Babylon
 
         bool IExtensionPlugin.UninitializePlugin()
         {
-            // Remove menu from main menu bar
+            // Remove menu from main menu bar and close the form
             MGlobal.executeCommand($@"deleteUI -menu ""{MenuPath}"";");
 
             MGlobal.displayInfo("Babylon plug-in uninitialized");
+
+            toBabylon.disposeForm()
+            
             return true;
         }
 
@@ -58,15 +61,19 @@ namespace Maya2Babylon
             form.Show();
             form.BringToFront();
             form.WindowState = FormWindowState.Normal;
-            form.FormClosed += (object sender, FormClosedEventArgs e) =>
+            form.closingByUser = () => { return disposeForm(); };
+            // TODO - save states - FORM: checkboxes and inputs. MEL: reselected meshes / nodes?
+            form.closingByShutDown = () => { return disposeForm(); };
+            // form.closingByCrash = () => { return disposeForm(); };
+        }
+        public static bool disposeForm()
+        {
+            if (form != null)
             {
-                if (form == null)
-                {
-                    return;
-                }
                 form.Dispose();
                 form = null;
-            };
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Maya crashes when the plugin is _uninitialized_ but form is still open. - Uninitialized function closes the form now.
The (x) button at the top of the window - Override the default function to close the form.
**TODO:** State saving for crash handling and operating system shut down. 