### PR TITLE
Use correct parent when exporting meshes. Fixes #247

### DIFF
--- a/Maya/Exporter/BabylonExporter.Node.cs
+++ b/Maya/Exporter/BabylonExporter.Node.cs
@@ -45,7 +45,10 @@ namespace Maya2Babylon
             {
                 RaiseVerbose("BabylonExporter.Node | Hierarchy", 2);
 
-                MObject parentMObject = mFnTransform.parent(0);
+                var mDagPath = new MDagPath(mFnTransform.dagPath);
+                mDagPath.pop();
+
+                MObject parentMObject = mDagPath.node;
                 // Children of World node don't have parent in Babylon
                 if (parentMObject.apiType != MFn.Type.kWorld)
                 {


### PR DESCRIPTION
Currently the exporter uses the id of the first parent of a mesh as its parentId when exporting it. This results in meshes having an incorrect parent and therefore incorrect positions and rotations in the scene.

In the example scene I attached to issue #247 the Outliner shows the correct object hierarchy:
![image](https://user-images.githubusercontent.com/723221/42230574-a0d555be-7ee9-11e8-835b-81350134b7e2.png)
The exporter however exports both cubes as children of group1:
![image](https://user-images.githubusercontent.com/723221/42230661-cf93b404-7ee9-11e8-9ea2-85c34d39f917.png)

After the changes in this PR both cubes are exported and grouped correctly:
![image](https://user-images.githubusercontent.com/723221/42230803-311590a8-7eea-11e8-8dc0-f18a686763c9.png)
