### PR TITLE
[Skin] vertex bone checks

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Mesh.cs
@@ -374,11 +374,6 @@ namespace Max2Babylon
                     accessorWeights.count = globalVerticesSubMesh.Count;
                 }
 
-                if (hasBonesExtra)
-                {
-                    RaiseWarning("Too many bones influences per vertex. glTF only support up to 4 bones influences per vertex. The result may not be as expected.", 3);
-                }
-
                 // Morph targets positions and normals
                 if (babylonMorphTargetManager != null)
                 {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -100,6 +100,11 @@ namespace Max2Babylon
 
                 return new List<IIGameNode>();
             }
+            if(rootNodes.Count <= 0)
+            {
+                RaiseWarning("Skin has no bones.", logRank);
+                return new List<IIGameNode>();
+            }
 
             // starting from the root, sort the nodes by depth first (add the children before the siblings)
             List<IIGameNode> sorted = new List<IIGameNode>();

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -28,7 +28,7 @@ namespace Max2Babylon
 
         public bool ExportQuaternionsInsteadOfEulers { get; set; }
 
-        private bool isBabylonExported;
+        private bool isBabylonExported, isGltfExported;
 
         private string exporterVersion = "1.2.12";
 
@@ -159,6 +159,7 @@ namespace Max2Babylon
 
             string outputFormat = exportParameters.outputFormat;
             isBabylonExported = outputFormat == "babylon" || outputFormat == "binary babylon";
+            isGltfExported = outputFormat == "gltf" || outputFormat == "glb";
 
             // Save scene
             if (exportParameters.autoSave3dsMaxFile)
@@ -401,7 +402,7 @@ namespace Max2Babylon
             ReportProgressChanged(100);
 
             // Export glTF
-            if (outputFormat == "gltf" || outputFormat == "glb")
+            if (isGltfExported)
             {
                 bool generateBinary = outputFormat == "glb";
                 ExportGltf(babylonScene, outputDirectory, outputFileName, generateBinary);


### PR DESCRIPTION
Changes:
- ignore bones with weight <= 0
- output vertex indices for vertices with >4 bones (gltf) or >8 bones (babylon)
- add check/warning for skins without bones (previously exception)

Possible issues:
- Many duplicate messages (see below image). This was already the case for babylon, before this pull request, the difference being I added this message for glTF and added the vertex index to the ouput. This begs the question: is there a reason for processing the same vertex index multiple times?

Already existing issues, even before this pull request:
- I can't get the skinned animation to play in babylon.js (the one that comes with "export & run), but it works correctly in three.js and the [online babylon viewer](https://sandbox.babylonjs.com/).
- The cone is invisible in three.js, but not in babylon!

![image](https://user-images.githubusercontent.com/3010534/42505471-186b5128-843f-11e8-98ae-083491e7dfed.png)

max file (max2016) & gltf:
[skin-stuff.zip](https://github.com/BabylonJS/Exporters/files/2180031/skin-stuff.zip)


