### PR TITLE
set manifest file export enabled by default

### DIFF
--- a/Blender/src/babylon-js/exporter_settings_panel.py
+++ b/Blender/src/babylon-js/exporter_settings_panel.py
@@ -75,7 +75,7 @@ class ExporterSettingsPanel(bpy.types.Panel):
     bpy.types.Scene.writeManifestFile = bpy.props.BoolProperty(
         name='Write .manifest file',
         description="Automatically create or update [filename].babylon.manifest for this file",
-        default = False,
+        default = True,
         )
     bpy.types.Scene.currentActionOnly = bpy.props.BoolProperty(
         name='Only Currently Assigned Actions',


### PR DESCRIPTION
This PR enables the "Write .manifest file" option by default.