### PR TITLE
Guid conflict bugfix mistake

### DIFF
--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -511,7 +511,12 @@ namespace Max2Babylon
                 if (guids.ContainsKey(uid))
                 {
                     // If the uid is already used by another node
-                    // This should be very rare, but it is perhaps possible when merging max scenes, or when cloning nodes?
+                    // This should be very rare, but it is possible:
+                    // - when merging max scenes?
+                    // - when cloning IAnimatable objects?
+                    // - when exporting old assets that were created before GUID uniqueness was checked
+                    // - when exporting parts of a scene separately, creating equal guids, and after that exporting them together
+                    // All of the above problems disappear after exporting AGAIN, because the GUIDs will be unique then.
                     if (guids[uid].Equals(node as IInterfaceServer) == false)
                     {
                         // Remove old uid
@@ -531,7 +536,10 @@ namespace Max2Babylon
             {
                 uid = Guid.NewGuid();
                 // verify that we create a unique guid
-                while(guids.ContainsKey(uid))
+                // there is still a possibility for a guid conflict:
+                //   e.g. when we export parts of the scene separately an equal Guid can be generated...
+                // only after re-exporting again after that will all guids be unique...
+                while (guids.ContainsKey(uid))
                     uid = Guid.NewGuid();
                 guids.Add(uid, node);
                 node.AddAppDataChunk(Loader.Class_ID, SClass_ID.Basenode, 0, uid.ToByteArray());

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -503,7 +503,7 @@ namespace Max2Babylon
             var uidData = node.GetAppDataChunk(Loader.Class_ID, SClass_ID.Basenode, 0);
             Guid uid;
 
-            // If current node already has an uid
+            // If current node already has a uid
             if (uidData != null)
             {
                 uid = new Guid(uidData.Data);
@@ -511,12 +511,14 @@ namespace Max2Babylon
                 if (guids.ContainsKey(uid))
                 {
                     // If the uid is already used by another node
+                    // This should be very rare, but it is perhaps possible when merging max scenes, or when cloning nodes?
                     if (guids[uid].Equals(node as IInterfaceServer) == false)
                     {
                         // Remove old uid
                         node.RemoveAppDataChunk(Loader.Class_ID, SClass_ID.Basenode, 0);
                         // Create a new uid for current node
                         uid = Guid.NewGuid();
+                        guids.Add(uid, node);
                         node.AddAppDataChunk(Loader.Class_ID, SClass_ID.Basenode, 0, uid.ToByteArray());
                     }
                 }
@@ -528,6 +530,10 @@ namespace Max2Babylon
             else
             {
                 uid = Guid.NewGuid();
+                // verify that we create a unique guid
+                while(guids.ContainsKey(uid))
+                    uid = Guid.NewGuid();
+                guids.Add(uid, node);
                 node.AddAppDataChunk(Loader.Class_ID, SClass_ID.Basenode, 0, uid.ToByteArray());
             }
 


### PR DESCRIPTION
- Guids were not stored until requested the second time; this could potentially cause conflicts.
- Clarify an existing problem with Guid generation in comments (see below). Conflicts may still occur. This must be discussed (will create a separate issue).