### PR TITLE
export babylonbinarymeshdata file

### DIFF
--- a/3ds Max/CHANGELOG.md
+++ b/3ds Max/CHANGELOG.md
@@ -49,3 +49,7 @@
 ## v1.3.12
 **Fixed bugs:**
 - Fixed bug where texture names are changed when exporting from the exporter(https://github.com/BabylonJS/Exporters/issues/379)
+
+## v1.3.13
+**Fixed bugs:**
+- Fixed bug where babylonbinarymeshdata file was not getting copied to the output directory(https://github.com/BabylonJS/Exporters/issues/401)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -33,7 +33,7 @@ namespace Max2Babylon
         private bool optimizeAnimations;
         private bool exportNonAnimated;
 
-        private string exporterVersion = "1.3.12";
+        private string exporterVersion = "1.3.13";
 
         void ReportProgressChanged(int progress)
         {
@@ -503,10 +503,15 @@ namespace Max2Babylon
                         var tempFilePath = Path.Combine(tempBinaryOutputDirectory, file);
                         var outputFile = Path.Combine(outputDirectory, file);
                         moveFileToOutputDirectory(tempFilePath, outputFile, exportParameters);
-                        break;
+                    }
+                    else if (filePath.EndsWith(".babylonbinarymeshdata"))
+                    {
+                        var file = Path.GetFileName(filePath);
+                        var tempFilePath = Path.Combine(tempBinaryOutputDirectory, file);
+                        var outputFile = Path.Combine(outputDirectory, file);
+                        moveFileToOutputDirectory(tempFilePath, outputFile, exportParameters);
                     }
                 }
-
             }
             if (outputFormat == "glb")
             {


### PR DESCRIPTION
## v1.3.13
**Fixed bugs:**
- Fixed bug where babylonbinarymeshdata file was not getting copied to the output directory(https://github.com/BabylonJS/Exporters/issues/401)