### PR TITLE
Material-ID Allocation fix for Arnold in Max 2019 (and future releases)

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -441,7 +441,7 @@ namespace Max2Babylon
                 babylonMaterial.emissive = emissionColor.Multiply(emissionWeight);
 
                 // --- Textures ---
-                // 1 - base_color ; 5 - diffuse_roughness ; 9 - metalness ; 10 - transparent
+                // 1 - base_color ; 5 - specular_roughness ; 9 - metalness ; 10 - transparent
                 ITexmap colorTexmap = _getTexMap(materialNode, 1);
                 ITexmap alphaTexmap = _getTexMap(materialNode, 10);
                 babylonMaterial.baseTexture = ExportBaseColorAlphaTexture(colorTexmap, alphaTexmap, babylonMaterial.baseColor, babylonMaterial.alpha, babylonScene, name);
@@ -506,8 +506,20 @@ namespace Max2Babylon
                         }
                     }
 
-                    babylonMaterial.normalTexture = ExportPBRTexture(materialNode, 20, babylonScene);
-                    babylonMaterial.emissiveTexture = ExportPBRTexture(materialNode, 30, babylonScene);
+                    var numOfTexMapSlots = materialNode.MaxMaterial.NumSubTexmaps;
+
+                    for (int i = 0; i < numOfTexMapSlots; i++)
+                    {
+                        if (materialNode.MaxMaterial.GetSubTexmapSlotName(i) == "normal")
+                        {
+                            babylonMaterial.normalTexture = ExportPBRTexture(materialNode, i, babylonScene);
+                        }
+
+                        if (materialNode.MaxMaterial.GetSubTexmapSlotName(i) == "emission")
+                        {
+                            babylonMaterial.emissiveTexture = ExportPBRTexture(materialNode, i, babylonScene);
+                        }
+                    }
                 }
 
                 // Constraints
@@ -522,7 +534,13 @@ namespace Max2Babylon
                     babylonMaterial.transparencyMode = (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHABLEND;
                 }
 
-                if (babylonMaterial.emissiveTexture != null)
+                var emissioncolor = propertyContainer.QueryProperty("emission_color").GetPoint3Property().ToArray();
+
+                if (emissioncolor != null)
+                {
+                    babylonMaterial.emissive = emissioncolor;
+                }
+                else
                 {
                     babylonMaterial.emissive = new[] { 1.0f, 1.0f, 1.0f };
                 }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -198,7 +198,7 @@ namespace Max2Babylon
 
                 var extension = Path.GetExtension(baseColorTexture.Map.FullFilePath).ToLower();
                 if (baseColorTexture.AlphaSource == 3 && // 'None (Opaque)'
-                    extension == ".jpg" || extension == ".jpeg" || extension == ".bmp")
+                    extension == ".jpg" || extension == ".jpeg" || extension == ".bmp" || extension == ".png" )
                 {
                     // Copy base color image
                     return ExportTexture(baseColorTexture, babylonScene);


### PR DESCRIPTION
- fixed material-slot allocation for Arnold materials to better withstand changes to slot IDs (due to feature changes on arnold material) -> Only for normal and emissive maps
- also added transfer of emissive color property to glTF export in case a texture exists

- optimized material-alphasettings-export by adding .png to valid extensions when exporting opaque materials