### PR TITLE
Fix older 3dsMax versions compatibility

### DIFF
--- a/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
+++ b/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
@@ -371,10 +371,8 @@
 if not exist "$(SolutionDir)assemblies\2015 - 2016" mkdir "$(SolutionDir)assemblies\2015 - 2016"
 del "$(SolutionDir)assemblies\2015 - 2016\*.dll"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2015 - 2016\"
-if exist "C:\Program Files\Autodesk\3ds Max 2015\bin\assemblies\" copy "$(SolutionDir)assemblies\2015 - 2016\*.dll" "C:\Program Files\Autodesk\3ds Max 2015\bin\assemblies\"
-if exist "C:\Program Files\Autodesk\3ds Max 2016\bin\assemblies\" copy "$(SolutionDir)assemblies\2015 - 2016\*.dll" "C:\Program Files\Autodesk\3ds Max 2016\bin\assemblies\"
-if exist "D:\Programmes\Autodesk\3ds Max 2015\bin\assemblies\" copy "$(SolutionDir)assemblies\2015 - 2016\*.dll" "D:\Programmes\Autodesk\3ds Max 2015\bin\assemblies\"
-if exist "D:\Programmes\Autodesk\3ds Max 2016\bin\assemblies\" copy "$(SolutionDir)assemblies\2015 - 2016\*.dll" "D:\Programmes\Autodesk\3ds Max 2016\bin\assemblies\"</PostBuildEvent>
+if exist "%ADSK_3DSMAX_x64_2015%bin\assemblies\" copy "$(SolutionDir)assemblies\2015 - 2016\*.dll" "%ADSK_3DSMAX_x64_2015%bin\assemblies\"
+if exist "%ADSK_3DSMAX_x64_2016%bin\assemblies\" copy "$(SolutionDir)assemblies\2015 - 2016\*.dll" "%ADSK_3DSMAX_x64_2016%bin\assemblies\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
+++ b/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
@@ -371,8 +371,7 @@
 if not exist "$(SolutionDir)assemblies\2017" mkdir "$(SolutionDir)assemblies\2017"
 del "$(SolutionDir)assemblies\2017\*.dll"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2017\"
-if exist "C:\Program Files\Autodesk\3ds Max 2017\bin\assemblies\" copy "$(SolutionDir)assemblies\2017\*.dll" "C:\Program Files\Autodesk\3ds Max 2017\bin\assemblies\"
-if exist "D:\Program Files\Autodesk\3ds Max 2017\bin\assemblies\" copy "$(SolutionDir)assemblies\2017\*.dll" "D:\Program Files\Autodesk\3ds Max 2017\bin\assemblies\"</PostBuildEvent>
+if exist "%ADSK_3DSMAX_x64_2017%bin\assemblies\" copy "$(SolutionDir)assemblies\2017\*.dll" %ADSK_3DSMAX_x64_2017%bin\assemblies\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
+++ b/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
@@ -372,8 +372,7 @@
 if not exist "$(SolutionDir)assemblies\2018" mkdir "$(SolutionDir)assemblies\2018"
 del "$(SolutionDir)assemblies\2018\*.dll"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2018\"
-if exist "C:\Program Files\Autodesk\3ds Max 2018\bin\assemblies\" copy "$(SolutionDir)assemblies\2018\*.dll" "C:\Program Files\Autodesk\3ds Max 2018\bin\assemblies\"
-if exist "D:\Programmes\Autodesk\3ds Max 2018\bin\assemblies\" copy "$(SolutionDir)assemblies\2018\*.dll" "D:\Programmes\Autodesk\3ds Max 2018\bin\assemblies\"</PostBuildEvent>
+if exist "%ADSK_3DSMAX_x64_2018%bin\assemblies\" copy "$(SolutionDir)assemblies\2018\*.dll" "%ADSK_3DSMAX_x64_2018%bin\assemblies\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/3ds Max/Max2Babylon/2019/Max2Babylon2019.csproj
+++ b/3ds Max/Max2Babylon/2019/Max2Babylon2019.csproj
@@ -372,8 +372,7 @@
 if not exist "$(SolutionDir)assemblies\2019" mkdir "$(SolutionDir)assemblies\2019"
 del "$(SolutionDir)assemblies\2019\*.dll"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2019\"
-if exist "C:\Program Files\Autodesk\3ds Max 2019\bin\assemblies\" copy "$(SolutionDir)assemblies\2019\*.dll" "C:\Program Files\Autodesk\3ds Max 2019\bin\assemblies\"
-if exist "D:\Programmes\Autodesk\3ds Max 2019\bin\assemblies\" copy "$(SolutionDir)assemblies\2019\*.dll" "D:\Programmes\Autodesk\3ds Max 2019\bin\assemblies\"</PostBuildEvent>
+if exist "%ADSK_3DSMAX_x64_2019%bin\assemblies\" copy "$(SolutionDir)assemblies\2019\*.dll" "%ADSK_3DSMAX_x64_2019%bin\assemblies\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
+++ b/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
@@ -153,7 +153,8 @@ namespace Max2Babylon
             int numFailed = 0;
             for (int i = 0; i < numNodeIDs; ++i)
             {
-                if (!uint.TryParse(properties[3 + i], out uint id))
+                uint id;
+                if (!uint.TryParse(properties[3 + i], out id))
                 {
                     ++numFailed;
                     continue;

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Animation.cs
@@ -120,7 +120,9 @@ namespace Max2Babylon
                         string id = maxNode.GetGuid().ToString();
                         BabylonNode babylonNode = babylonNodes.Find(node => node.id.Equals(id));
 
-                        if (babylonNode != null && nodeToGltfNodeMap.TryGetValue(babylonNode, out GLTFNode gltfNode))
+                        GLTFNode gltfNode;
+
+                        if (babylonNode != null && nodeToGltfNodeMap.TryGetValue(babylonNode, out gltfNode))
                         {
                             ExportNodeAnimation(gltfAnimation, startFrame, endFrame, gltf, babylonNode, gltfNode, babylonScene);
                         }

--- a/3ds Max/Max2Babylon/Forms/AnimationGroupControl.cs
+++ b/3ds Max/Max2Babylon/Forms/AnimationGroupControl.cs
@@ -48,7 +48,8 @@ namespace Max2Babylon
 
                 MaxNodeTree.BeginUpdate();
                 MaxNodeTree.QueueSetNodes(info.NodeHandles, false);
-                MaxNodeTree.ApplyQueuedChanges(out List<uint> handles, false);
+                List<uint> handles;
+                MaxNodeTree.ApplyQueuedChanges(out handles, false);
                 MaxNodeTree.EndUpdate();
 
                 // if the nodes changed on max' side, even though the data has not changed, the list may be different (e.g. deleted nodes)
@@ -72,7 +73,8 @@ namespace Max2Babylon
 
                 MaxNodeTree.BeginUpdate();
                 MaxNodeTree.QueueSetNodes(null, false);
-                MaxNodeTree.ApplyQueuedChanges(out List<uint> handles, false);
+                List<uint> handles;
+                MaxNodeTree.ApplyQueuedChanges(out handles, false);
                 MaxNodeTree.EndUpdate();
             }
         }
@@ -99,7 +101,9 @@ namespace Max2Babylon
                 return;
             }
 
-            if (!int.TryParse(startTextBox.Text, out int newFrameStart))
+            int newFrameStart;
+
+            if (!int.TryParse(startTextBox.Text, out newFrameStart))
                 newFrameStart = currentInfo.FrameStart;
 
             bool changed = newFrameStart != currentInfo.FrameStart;
@@ -114,7 +118,9 @@ namespace Max2Babylon
                 return;
             }
 
-            if (!int.TryParse(endTextBox.Text, out int newFrameEnd))
+            int newFrameEnd;
+
+            if (!int.TryParse(endTextBox.Text, out newFrameEnd))
                 newFrameEnd = currentInfo.FrameEnd;
 
             bool changed = newFrameEnd != currentInfo.FrameEnd;
@@ -131,9 +137,12 @@ namespace Max2Babylon
 
             string newName = nameTextBox.Text;
 
-            if (!int.TryParse(startTextBox.Text, out int newFrameStart))
+            int newFrameStart;
+
+            if (!int.TryParse(startTextBox.Text, out newFrameStart))
                 newFrameStart = confirmedInfo.FrameStart;
-            if (!int.TryParse(endTextBox.Text, out int newFrameEnd))
+            int newFrameEnd;
+            if (!int.TryParse(endTextBox.Text, out newFrameEnd))
                 newFrameEnd = confirmedInfo.FrameEnd;
 
             List<uint> newHandles;

--- a/3ds Max/Max2Babylon/Forms/MaxNodeTreeView.cs
+++ b/3ds Max/Max2Babylon/Forms/MaxNodeTreeView.cs
@@ -131,7 +131,8 @@ namespace Max2Babylon
             foreach (uint nodeHandle in nodeHandles)
             {
                 // get visual node from tree or create it (as non-dummies)
-                if (!visualNodeMap.TryGetValue(nodeHandle, out VisualNode visualNode))
+                VisualNode visualNode;
+                if (!visualNodeMap.TryGetValue(nodeHandle, out visualNode))
                 {
                     IINode node = Loader.Core.RootNode.FindChildNode(nodeHandle);
 
@@ -167,7 +168,8 @@ namespace Max2Babylon
         }
         public void QueueRemoveNode(uint nodeHandle)
         {
-            if (!visualNodeMap.TryGetValue(nodeHandle, out VisualNode node))
+            VisualNode node;
+            if (!visualNodeMap.TryGetValue(nodeHandle, out node))
                 return;
 
             BeginUpdate();
@@ -314,7 +316,9 @@ namespace Max2Babylon
             if(setNonDummy)
                 nodeInfo.IsDummy = false;
 
-            if (previousAppliedHandles.TryGetValue(nodeInfo.MaxNode.Handle, out bool wasDummy))
+            bool wasDummy;
+
+            if (previousAppliedHandles.TryGetValue(nodeInfo.MaxNode.Handle, out wasDummy))
             {
                 if (wasDummy)
                     nodeInfo.State = nodeInfo.IsDummy ? VisualNodeInfo.EState.Saved : VisualNodeInfo.EState.Upgraded;
@@ -342,7 +346,9 @@ namespace Max2Babylon
             if (keepAsDummy)
             {
                 nodeInfo.IsDummy = true;
-                if (previousAppliedHandles.TryGetValue(nodeInfo.MaxNode.Handle, out bool wasDummy))
+                bool wasDummy;
+
+                if (previousAppliedHandles.TryGetValue(nodeInfo.MaxNode.Handle, out wasDummy))
                     nodeInfo.State = wasDummy ? VisualNodeInfo.EState.Saved : VisualNodeInfo.EState.Downgraded;
                 else
                     nodeInfo.State = VisualNodeInfo.EState.Added;

--- a/3ds Max/Max2Babylon/Forms/MultiExportForm.cs
+++ b/3ds Max/Max2Babylon/Forms/MultiExportForm.cs
@@ -120,7 +120,8 @@ namespace Max2Babylon
             {
                 var row = ExportItemGridView.Rows[e.RowIndex];
                 string str = row.Cells[e.ColumnIndex].Value as string;
-                if(!string.IsNullOrWhiteSpace(str) && !Uri.TryCreate(str, UriKind.Absolute, out Uri uri))
+                Uri uri;
+                if (!string.IsNullOrWhiteSpace(str) && !Uri.TryCreate(str, UriKind.Absolute, out uri))
                 {
                     e.Cancel = true;
                 }

--- a/3ds Max/Max2Babylon/MaxScriptManager.cs
+++ b/3ds Max/Max2Babylon/MaxScriptManager.cs
@@ -12,6 +12,10 @@ namespace Max2Babylon
 
         public static void Export(ExportParameters exportParameters)
         {
+            if (Loader.Class_ID == null)
+            {
+                Loader.AssemblyMain();
+            }
             // Check output format is valid
             List<string> validFormats = new List<string>(new string[] { "babylon", "binary babylon", "gltf", "glb" });
             if (!validFormats.Contains(exportParameters.outputFormat))

--- a/SharedProjects/GltfExport.Entities/GLTFImage.cs
+++ b/SharedProjects/GltfExport.Entities/GLTFImage.cs
@@ -9,7 +9,7 @@ namespace GLTFExport.Entities
         [DataMember(EmitDefaultValue = false)]
         public string uri
         {
-            get => _uri;
+            get { return _uri; }
             set
             {
                 if (value == null)


### PR DESCRIPTION
I have just used the 3dsMax 2017 exporter in *Debug* mode, and it didn't compile due to too recent syntax used for out variables. I have fixed that and also add the possibility to use the exporter in Maxscript without having the dll files in `/bin/assemblies` folder (3dsMax makes a startup check in this folder to initialize plugin with their `Class_ID`).

Here are the different commits :

- Be able to initialize the Babylon Exporter plugin without any Autodesk startup checks.
- Do not use **C# 7.0** syntax for out variables to not break compatibility with older versions of .NET Frameworks used by 3dsMax.
- Use Autodesk standard environment variables instead of guessing drives in VS CSharp projects files.