### PR TITLE
Max2Babylon packaging script

### DIFF
--- a/3ds Max/Max2Babylon/Max2Babylon_Package.py
+++ b/3ds Max/Max2Babylon/Max2Babylon_Package.py
@@ -1,0 +1,28 @@
+import os
+import zipfile
+import shutil
+
+versions = ['2015', '2017', '2018', '2019']
+projectFolderPrefix = './'
+buildPathPrefix = '/bin/Release/'
+
+packageFolderPrefix = '../'
+Max2BabylonPackagePrefix = 'Max2Babylon-'
+Max2BabylonVersion = '1.4.0'
+
+with zipfile.ZipFile(packageFolderPrefix + Max2BabylonPackagePrefix + Max2BabylonVersion + '.zip', 'w' ) as outputZip:
+
+    for version in versions:
+        # get file paths
+        buildPath = projectFolderPrefix + version + buildPathPrefix
+        buildDlls = [ dll for dll in os.listdir(buildPath) if dll.endswith('.dll')]
+
+        if version == '2015':
+            packagePath = '2015 - 2016' + '/'
+        else:
+            packagePath = version + '/'
+
+        # copy bins to publish location
+        for dll in buildDlls:
+            outputZip.write(buildPath + dll, packagePath + dll)
+


### PR DESCRIPTION
Rudimentary python script to allow for quicker packaging workflow. currently retrieves dll binaries in each project build folder, and produces a .zip using the provided version number.