### PR TITLE
Fix merge regression, Re-Add animation group selection

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
+++ b/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
@@ -284,26 +284,21 @@ namespace Max2Babylon
             Loader.Core.RootNode.SetStringArrayProperty(s_AnimationListPropertyName, animationPropertyNameList);
         }
 
-        public void SaveToJson(string filePath)
+        public void SaveToJson(string filePath, List<AnimationGroup> exportList)
         {
-            List<AnimationGroup> toSerailize = new List<AnimationGroup>();
-            string[] animationPropertyNamesInfo = Loader.Core.RootNode.GetStringArrayProperty(s_AnimationListPropertyName);
-
-            foreach (string propertyNameStr in animationPropertyNamesInfo)
-            {
-                AnimationGroup info = new AnimationGroup();
-                info.LoadFromData(propertyNameStr);
-                toSerailize.Add(info);
-            }
-
-            File.WriteAllText(filePath, JsonConvert.SerializeObject(toSerailize));
+            File.WriteAllText(filePath, JsonConvert.SerializeObject(exportList));
         }
 
-        public void LoadFromJson(string jsonContent)
+        public void LoadFromJson(string jsonContent, bool merge = false)
         {
-            Clear();
+            List<string> animationPropertyNameList = Loader.Core.RootNode.GetStringArrayProperty(s_AnimationListPropertyName).ToList();
 
-            List<string> animationPropertyNameList = new List<string>();
+            if (!merge)
+            {
+                animationPropertyNameList = new List<string>();
+                Clear();
+            }
+            
             List<AnimationGroup> animationGroupsData = JsonConvert.DeserializeObject<List<AnimationGroup>>(jsonContent);
 
             foreach (AnimationGroup animData in animationGroupsData)
@@ -365,7 +360,21 @@ namespace Max2Babylon
             
             foreach (AnimationGroup animData in animationGroupsData)
             {
-                animationPropertyNameList.Add(animData.SerializedId.ToString());
+                string id = animData.SerializedId.ToString();
+
+                if (merge)
+                {
+                    //if json are merged check if the same animgroup is already in list
+                    //and skip in that case
+                    if (!animationPropertyNameList.Contains(id))
+                    {
+                        animationPropertyNameList.Add(animData.SerializedId.ToString());
+                    }
+                }
+                else
+                {
+                    animationPropertyNameList.Add(animData.SerializedId.ToString());
+                }
             }
 
             Loader.Core.RootNode.SetStringArrayProperty(s_AnimationListPropertyName, animationPropertyNameList);

--- a/3ds Max/Max2Babylon/Forms/AnimationForm.cs
+++ b/3ds Max/Max2Babylon/Forms/AnimationForm.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using Autodesk.Max;
 
@@ -77,31 +79,52 @@ namespace Max2Babylon
             animationListBinding.ResetBindings(false);
             Loader.Global.SetSaveRequiredFlag(true, false);
 
+            AnimationListBox.ClearSelected();
             AnimationListBox.SelectedItem = info;
         }
 
         private void deleteAnimationButton_Click(object sender, EventArgs e)
         {
-            int selectedIndex = AnimationListBox.SelectedIndex;
-
-            if (selectedIndex < 0)
+           
+            if (AnimationListBox.SelectedIndices.Count <= 0)
+            {
+                MessageBox.Show("Select at least one Animation Group");
                 return;
+            }
 
-            AnimationGroup selectedItem = (AnimationGroup)AnimationListBox.SelectedItem;
-            
-            // delete item
-            selectedItem.DeleteFromData();
+            //retrieve list of selected animation groups to delete 
+            List<AnimationGroup> deletedAnimationGroups = new List<AnimationGroup>();
 
-            // update list
-            animationGroups.Remove(selectedItem);
+            foreach (int selectedIndex in AnimationListBox.SelectedIndices)
+            {
+
+                if (selectedIndex < 0)
+                    return;
+
+                deletedAnimationGroups.Add((AnimationGroup)AnimationListBox.Items[selectedIndex]);
+                
+            }
+
+            foreach (AnimationGroup deletedItem in deletedAnimationGroups)
+            {
+                // delete item
+                deletedItem.DeleteFromData();
+
+                // update list
+                animationGroups.Remove(deletedItem);
+            }
+
             animationGroups.SaveToData();
             animationListBinding.ResetBindings(false);
             Loader.Global.SetSaveRequiredFlag(true, false);
 
             // get new selected item at the current index, if any
-            selectedIndex = Math.Min(selectedIndex, AnimationListBox.Items.Count - 1);
-            selectedItem = selectedIndex < 0 ? null : (AnimationGroup)AnimationListBox.Items[selectedIndex];
-            AnimationListBox.SelectedItem = selectedItem;
+            if (AnimationListBox.Items.Count > 0)
+            {
+                int newIndex = Math.Min(AnimationListBox.SelectedIndices[0], AnimationListBox.Items.Count - 1);
+                AnimationGroup newSelectedItem = newIndex < 0 ? null : (AnimationGroup)AnimationListBox.Items[newIndex];
+                AnimationListBox.SelectedItem = newSelectedItem;
+            }
         }
 
         private void animationList_SelectedValueChanged(object sender, EventArgs e)
@@ -151,15 +174,33 @@ namespace Max2Babylon
 
         private void ExportBtn_Click(object sender, EventArgs e)
         {
+            if (AnimationListBox.SelectedIndices.Count <= 0)
+            {
+                MessageBox.Show("Select at least one Animation Group");
+                return;
+            }
+
+            List<AnimationGroup> exportList = AnimationListBox.SelectedItems.Cast<AnimationGroup>().ToList();
+
             SaveFileDialog saveFileDialog1 = new SaveFileDialog();
             saveFileDialog1.Filter = "JSON File|*.json";
             saveFileDialog1.Title = "Save an Export Info File";
 
             if (saveFileDialog1.ShowDialog() != DialogResult.OK) return;
-            animationGroups.SaveToJson(saveFileDialog1.FileName);
+            animationGroups.SaveToJson(saveFileDialog1.FileName, exportList);
         }
 
         private void ImportBtn_Click(object sender, EventArgs e)
+        {
+            LoadDialog();
+        }
+
+        private void MergeBtn_Click(object sender, EventArgs e)
+        {
+            LoadDialog(true);
+        }
+
+        private void LoadDialog(bool merge = false)
         {
             string jsonPath = string.Empty;
             string jsonContent = string.Empty;
@@ -179,13 +220,35 @@ namespace Max2Babylon
 
                     using (StreamReader reader = new StreamReader(fileStream))
                     {
+                        BindingSource bindingSource = (BindingSource)AnimationListBox.DataSource;
+                        System.Collections.IList SourceList = bindingSource.List;
+                        SourceList.Clear();
                         jsonContent = reader.ReadToEnd();
-                        animationGroups.LoadFromJson(jsonContent);
+                        animationGroups.LoadFromJson(jsonContent, merge);
                         animationListBinding.ResetBindings(false);
                         Loader.Global.SetSaveRequiredFlag(true, false);
                     }
                 }
             }
+        }
+
+
+        //remove aniamtion groups with no nodes
+        private void cleanBtn_Click(object sender, EventArgs e)
+        {
+            foreach (AnimationGroup item in AnimationListBox.Items)
+            {
+                
+                if (item.AnimationGroupNodes != null && item.AnimationGroupNodes.Count>0)
+                {
+                   continue;
+                }
+                item.DeleteFromData();
+                animationGroups.Remove(item);
+            }
+            animationGroups.SaveToData();
+            animationListBinding.ResetBindings(false);
+            Loader.Global.SetSaveRequiredFlag(true, false);
         }
 
         public void HighlightAnimationGroupOfSelection()


### PR DESCRIPTION
This pull request fixes a regression introduced by the merge conflict resolution of pull request #516 https://github.com/BabylonJS/Exporters/commit/88b37e6459159edb441a4fa7e7254ff4055498af 
which was later reverted via https://github.com/BabylonJS/Exporters/commit/61c69f89d15ff96e34bcc5b17ee820d471f50d20

This pull request Re-adds animation form related changes via https://github.com/BabylonJS/Exporters/commit/db4d9b2282c9fa46083ca42c30acc977dd42af19 and https://github.com/BabylonJS/Exporters/commit/74fe4fa949db63f6b91b343888270680c901a57e