### PR TITLE
3ds Max exporter batching improvements, add parameter saving, decouple export entrypoint from export button click callback.

### DIFF
--- a/3ds Max/Max2Babylon/ExportParameters.cs
+++ b/3ds Max/Max2Babylon/ExportParameters.cs
@@ -21,5 +21,9 @@
         public bool enableKHRTextureTransform = false;
         public bool enableKHRMaterialsUnlit = false;
         public Autodesk.Max.IINode exportNode;
+
+
+        public const string ModelFilePathProperty = "modelFilePathProperty";
+        public const string TextureFolderPathProperty = "textureFolderPathProperty";
     }
 }

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.Designer.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.Designer.cs
@@ -63,6 +63,7 @@
             this.butClose = new System.Windows.Forms.Button();
             this.toolTipDracoCompression = new System.Windows.Forms.ToolTip(this.components);
             this.butMultiExport = new System.Windows.Forms.Button();
+            this.saveOptionBtn = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
@@ -72,7 +73,7 @@
             this.butExport.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.butExport.Enabled = false;
             this.butExport.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.butExport.Location = new System.Drawing.Point(115, 245);
+            this.butExport.Location = new System.Drawing.Point(214, 245);
             this.butExport.Name = "butExport";
             this.butExport.Size = new System.Drawing.Size(197, 27);
             this.butExport.TabIndex = 100;
@@ -435,7 +436,7 @@
             this.butExportAndRun.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.butExportAndRun.Enabled = false;
             this.butExportAndRun.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.butExportAndRun.Location = new System.Drawing.Point(318, 245);
+            this.butExportAndRun.Location = new System.Drawing.Point(417, 245);
             this.butExportAndRun.Name = "butExportAndRun";
             this.butExportAndRun.Size = new System.Drawing.Size(197, 27);
             this.butExportAndRun.TabIndex = 102;
@@ -465,7 +466,7 @@
             // 
             this.butMultiExport.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.butMultiExport.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.butMultiExport.Location = new System.Drawing.Point(521, 245);
+            this.butMultiExport.Location = new System.Drawing.Point(620, 245);
             this.butMultiExport.Name = "butMultiExport";
             this.butMultiExport.Size = new System.Drawing.Size(197, 27);
             this.butMultiExport.TabIndex = 109;
@@ -473,11 +474,24 @@
             this.butMultiExport.UseVisualStyleBackColor = true;
             this.butMultiExport.Click += new System.EventHandler(this.butMultiExport_Click);
             // 
+            // saveOptionBtn
+            // 
+            this.saveOptionBtn.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.saveOptionBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.saveOptionBtn.Location = new System.Drawing.Point(12, 245);
+            this.saveOptionBtn.Name = "saveOptionBtn";
+            this.saveOptionBtn.Size = new System.Drawing.Size(197, 27);
+            this.saveOptionBtn.TabIndex = 110;
+            this.saveOptionBtn.Text = "Save";
+            this.saveOptionBtn.UseVisualStyleBackColor = true;
+            this.saveOptionBtn.Click += new System.EventHandler(this.saveOptionBtn_Click);
+            // 
             // ExporterForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(834, 561);
+            this.Controls.Add(this.saveOptionBtn);
             this.Controls.Add(this.butMultiExport);
             this.Controls.Add(this.butExportAndRun);
             this.Controls.Add(this.groupBox1);
@@ -540,5 +554,6 @@
         private System.Windows.Forms.CheckBox chkKHRTextureTransform;
         private System.Windows.Forms.CheckBox chkKHRMaterialsUnlit;
         private System.Windows.Forms.CheckBox chkExportMaterials;
+        private System.Windows.Forms.Button saveOptionBtn;
     }
 }

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -11,9 +11,6 @@ namespace Max2Babylon
 {
     public partial class ExporterForm : Form
     {
-        private const string ModelFilePathProperty = "modelFilePathProperty";
-        private const string TextureFolderPathProperty = "textureFolderPathProperty";
-
         private readonly BabylonExportActionItem babylonExportAction;
         private BabylonExporter exporter;
         private bool gltfPipelineInstalled = true;  // true if the gltf-pipeline is installed and runnable.
@@ -53,13 +50,13 @@ namespace Max2Babylon
 
         private void ExporterForm_Load(object sender, EventArgs e)
         {
-            string storedModelPath = Loader.Core.RootNode.GetStringProperty(ModelFilePathProperty,string.Empty);
+            string storedModelPath = Loader.Core.RootNode.GetStringProperty(ExportParameters.ModelFilePathProperty,string.Empty);
             string userRelativePath = Tools.ResolveRelativePath(storedModelPath);
             txtModelName.Text = userRelativePath;
             string absoluteModelPath = Tools.UnformatPath(txtModelName.Text);
             singleExportItem = new ExportItem(absoluteModelPath);
 
-            string storedFolderPath = Loader.Core.RootNode.GetStringProperty(TextureFolderPathProperty, string.Empty);
+            string storedFolderPath = Loader.Core.RootNode.GetStringProperty(ExportParameters.TextureFolderPathProperty, string.Empty);
             string formatedFolderPath = Tools.ResolveRelativePath(storedFolderPath);
             txtTextureName.Text = formatedFolderPath;
 
@@ -166,10 +163,10 @@ namespace Max2Babylon
             Tools.UpdateCheckBox(chkExportMaterials, Loader.Core.RootNode, "babylonjs_export_materials");
 
             string unformattedPath = Tools.UnformatPath(txtModelName.Text);
-            Loader.Core.RootNode.SetStringProperty(ModelFilePathProperty, Tools.RelativePathStore(unformattedPath));
+            Loader.Core.RootNode.SetStringProperty(ExportParameters.ModelFilePathProperty, Tools.RelativePathStore(unformattedPath));
 
-			string unformattedTextureFolderPath = Tools.UnformatPath(txtTextureName.Text);
-            Loader.Core.RootNode.SetStringProperty(TextureFolderPathProperty,Tools.RelativePathStore(unformattedTextureFolderPath));
+            string unformattedTextureFolderPath = Tools.UnformatPath(txtTextureName.Text);
+            Loader.Core.RootNode.SetStringProperty(ExportParameters.TextureFolderPathProperty,Tools.RelativePathStore(unformattedTextureFolderPath));
         }
             
 

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -110,7 +110,12 @@ namespace Max2Babylon
             return allSucceeded;
         }
 
-        private async Task<bool> DoExport(ExportItem exportItem, bool clearLogs = true)
+        private void saveOptionBtn_Click(object sender, EventArgs e)
+        {
+            SaveOptions();
+        }
+
+        private void SaveOptions()
         {
             Tools.UpdateCheckBox(chkManifest, Loader.Core.RootNode, "babylonjs_generatemanifest");
             Tools.UpdateCheckBox(chkWriteTextures, Loader.Core.RootNode, "babylonjs_writetextures");
@@ -131,6 +136,11 @@ namespace Max2Babylon
 
             string unformattedPath = Tools.UnformatPath(txtFilename.Text);
             Loader.Core.RootNode.SetLocalData(Tools.RelativePathStore(unformattedPath));
+        }
+
+        private async Task<bool> DoExport(ExportItem exportItem, bool clearLogs = true)
+        {
+            SaveOptions();
 
             exporter = new BabylonExporter();
 

--- a/3ds Max/Max2Babylon/MaxScriptManager.cs
+++ b/3ds Max/Max2Babylon/MaxScriptManager.cs
@@ -1,10 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Windows.Forms;
 
 namespace Max2Babylon
 {
     public class MaxScriptManager
     {
+        public static void Export()
+        {
+            string outputPath = Tools.ResolveRelativePath(Loader.Core.RootNode.GetLocalData());
+            Export(InitParameters(outputPath));
+        }
+
         public static void Export(string outputPath)
         {
             Export(InitParameters(outputPath));
@@ -48,12 +56,54 @@ namespace Max2Babylon
             exporter.Export(exportParameters);
         }
 
+
+        //leave the possibility to do get the outputh path from the babylon exporter with all the settings as presaved
         public static ExportParameters InitParameters(string outputPath)
         {
             ExportParameters exportParameters = new ExportParameters();
             exportParameters.outputPath = outputPath;
-            exportParameters.outputFormat = Path.GetExtension(outputPath).Substring(1);
+            exportParameters.outputFormat = Path.GetExtension(outputPath)?.Substring(1);
+            exportParameters.generateManifest = Loader.Core.RootNode.GetBoolProperty("babylonjs_generatemanifest");
+            exportParameters.writeTextures = Loader.Core.RootNode.GetBoolProperty("babylonjs_writetextures");
+            exportParameters.overwriteTextures = Loader.Core.RootNode.GetBoolProperty("babylonjs_overwritetextures");
+            exportParameters.exportHiddenObjects = Loader.Core.RootNode.GetBoolProperty("babylonjs_exporthidden");
+            exportParameters.autoSave3dsMaxFile = Loader.Core.RootNode.GetBoolProperty("babylonjs_autosave");
+            exportParameters.exportOnlySelected = Loader.Core.RootNode.GetBoolProperty("babylonjs_onlySelected");
+            exportParameters.exportTangents = Loader.Core.RootNode.GetBoolProperty("babylonjs_exporttangents");
+            exportParameters.scaleFactor = Loader.Core.RootNode.GetStringProperty("babylonjs_txtScaleFactor", "1");
+            exportParameters.txtQuality = Loader.Core.RootNode.GetStringProperty("babylonjs_txtCompression", "100");
+            exportParameters.mergeAOwithMR = Loader.Core.RootNode.GetBoolProperty("babylonjs_mergeAOwithMR");
+            exportParameters.dracoCompression = Loader.Core.RootNode.GetBoolProperty("babylonjs_dracoCompression");
+            exportParameters.enableKHRLightsPunctual = Loader.Core.RootNode.GetBoolProperty("babylonjs_khrLightsPunctual");
+            exportParameters.enableKHRTextureTransform = Loader.Core.RootNode.GetBoolProperty("babylonjs_khrTextureTransform");
+            exportParameters.enableKHRMaterialsUnlit = Loader.Core.RootNode.GetBoolProperty("babylonjs_khr_materials_unlit");
+            exportParameters.exportMaterials = Loader.Core.RootNode.GetBoolProperty("babylonjs_export_materials");
             return exportParameters;
         }
+
+        public static void ImportAnimationGroups(string jsonPath)
+        {
+            AnimationGroupList animationGroups = new AnimationGroupList();
+            var fileStream = File.Open(jsonPath, FileMode.Open);
+
+            using (StreamReader reader = new StreamReader(fileStream))
+            {
+                string jsonContent = reader.ReadToEnd();
+                animationGroups.LoadFromJson(jsonContent);
+            }
+        }
+
+        public static void MergeAnimationGroups(string jsonPath)
+        {
+            AnimationGroupList animationGroups = new AnimationGroupList();
+            var fileStream = File.Open(jsonPath, FileMode.Open);
+
+            using (StreamReader reader = new StreamReader(fileStream))
+            {
+                string jsonContent = reader.ReadToEnd();
+                animationGroups.LoadFromJson(jsonContent,true);
+            }
+        }
+
     }
 }

--- a/3ds Max/Max2Babylon/MaxScriptManager.cs
+++ b/3ds Max/Max2Babylon/MaxScriptManager.cs
@@ -9,8 +9,10 @@ namespace Max2Babylon
     {
         public static void Export()
         {
-            string outputPath = Tools.ResolveRelativePath(Loader.Core.RootNode.GetLocalData());
-            Export(InitParameters(outputPath));
+            string storedModelPath = Loader.Core.RootNode.GetStringProperty(ExportParameters.ModelFilePathProperty, string.Empty);
+            string userRelativePath = Tools.ResolveRelativePath(storedModelPath);
+            string absoluteModelPath = Tools.UnformatPath(userRelativePath);
+            Export(InitParameters(absoluteModelPath));
         }
 
         public static void Export(string outputPath)
@@ -63,6 +65,7 @@ namespace Max2Babylon
             ExportParameters exportParameters = new ExportParameters();
             exportParameters.outputPath = outputPath;
             exportParameters.outputFormat = Path.GetExtension(outputPath)?.Substring(1);
+            exportParameters.textureFolder = Loader.Core.RootNode.GetStringProperty("textureFolderPathProperty", string.Empty);
             exportParameters.generateManifest = Loader.Core.RootNode.GetBoolProperty("babylonjs_generatemanifest");
             exportParameters.writeTextures = Loader.Core.RootNode.GetBoolProperty("babylonjs_writetextures");
             exportParameters.overwriteTextures = Loader.Core.RootNode.GetBoolProperty("babylonjs_overwritetextures");


### PR DESCRIPTION
InitParameters() now get all saved options inside max
added "Save" button to force options to be registered
added export function with no parameters to match Babylon

basically, the idea is to have the possibility to batch exporter operation
to do this we could call Export() from max script, but there was no match between Babylon configuration and the export function,
in other, it was the internal export button that registered user options,
passing from the max script means that user need the possibility to force to save the specified options

I also exposed the merge and import  animation group from a JSON file
There are many tools that need to be built around this exporter.
I'm planning to expose all the animation group methods soon


