### PR TITLE
Python script for Changelog auto-completion

### DIFF
--- a/3ds Max/CHANGELOG.md
+++ b/3ds Max/CHANGELOG.md
@@ -194,6 +194,7 @@ not exported correctly using glTF
 (https://github.com/BabylonJS/Exporters/pull/498)
 
 ## v1.4.0
+### (2019-05-17 12:00:00)
 **Fixed Bugs**
 - Added @elpie89 's fix for null references when exporting Physical Material with no Texture
 (https://github.com/BabylonJS/Exporters/issues/509)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -33,7 +33,7 @@ namespace Max2Babylon
         private bool optimizeAnimations;
         private bool exportNonAnimated;
 
-        public static string exporterVersion = "1.4.0";
+        public static string exporterVersion = "1.4.1";
         public float scaleFactor = 1.0f;
 
         void ReportProgressChanged(int progress)

--- a/3ds Max/Max2Babylon/Max2Babylon_Package.py
+++ b/3ds Max/Max2Babylon/Max2Babylon_Package.py
@@ -22,7 +22,7 @@ lastVersionTime = ''
 # Retrieved for the "Exporter/BabylonExporter.cs" file
 
 Max2BabylonVersion = ''
-with open('Max2Babylon/Exporter/BabylonExporter.cs', 'r') as file_BabylonExporterCS:
+with open('Exporter/BabylonExporter.cs', 'r') as file_BabylonExporterCS:
     lineIndex = 0
     for line in file_BabylonExporterCS:
         lineIndex += 1
@@ -76,14 +76,14 @@ def updateChangelog () :
     response = requests.post(
         'https://api.github.com/graphql', headers=headers, json=query)
 
-    if (json.loads(response.text)['message']) :
+    if ('message' in json.loads(response.text)) :
         print(" ==> /!\\ Error when trying to reach the Github API : {0} \n".format(json.loads(response.text)['message']))
         return
 
     data = json.loads(response.text)['data']['repository']['pullRequests']['nodes']
 
     # Get last version date
-    with open('CHANGELOG.md', 'r') as file_Changelog:
+    with open('{0}CHANGELOG.md'.format(packageFolderPrefix), 'r') as file_Changelog:
         lineIndex = 0
         for line in reversed(file_Changelog.readlines()):
             lineIndex += 1
@@ -97,7 +97,7 @@ def updateChangelog () :
     # Then write PR titles in the Changelog
     list_bug = []
     list_enhancement = []
-    with open('CHANGELOG.md', 'a') as file_Changelog:
+    with open('{0}CHANGELOG.md'.format(packageFolderPrefix), 'a') as file_Changelog:
         file_Changelog.write("\n## v" + Max2BabylonVersion)
         file_Changelog.write("\n### ({0})".format(currentVersionTime))
 

--- a/3ds Max/Max2Babylon/Max2Babylon_Package.py
+++ b/3ds Max/Max2Babylon/Max2Babylon_Package.py
@@ -1,6 +1,12 @@
+# BEFORE USING THIS SCRIPT, PLEASE MAKE SURE PYTHON AND THE PACKAGES LISTED IN THE README.MD ARE INSTALLED.
+
+# ---------- IMPORTS ----------
 import os
 import zipfile
 import shutil
+import json     # Changelog
+import requests  # Changelog
+import datetime  # Changelog
 
 versions = ['2015', '2017', '2018', '2019']
 projectFolderPrefix = './'
@@ -8,7 +14,124 @@ buildPathPrefix = '/bin/Release/'
 
 packageFolderPrefix = '../'
 Max2BabylonPackagePrefix = 'Max2Babylon-'
-Max2BabylonVersion = '1.4.0'
+
+currentVersionTime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+lastVersionTime = ''
+
+# ---------- EXPORTER VERSION ----------
+# Retrieved for the "Exporter/BabylonExporter.cs" file
+
+Max2BabylonVersion = ''
+with open('Max2Babylon/Exporter/BabylonExporter.cs', 'r') as file_BabylonExporterCS:
+    lineIndex = 0
+    for line in file_BabylonExporterCS:
+        lineIndex += 1
+        if line.find('exporterVersion = "') != -1:
+            firstOcc = line.find('"')
+            lastOcc = line.find('"', firstOcc + 1)
+            Max2BabylonVersion = line[firstOcc + 1: lastOcc]
+            break
+file_BabylonExporterCS.close()
+# Be sure that the version has been found. Otherwise, raise a Value Error
+if (Max2BabylonVersion == ''):
+    raise ValueError(
+        "Impossible to fine line with 'string exporterVersion = \"' in the BabylonExporter.cs file")
+
+
+# ---------- UPDATING THE CHANGELOG.MD ----------
+
+# Get informations from the repo
+print("Please, enter your Github Access Token.")
+print("See the readme.md for more informations at ## Build package")
+print("Leave blank and press enter if you don't want to fill the Changelog")
+accessToken = str(input("Access Token : "))
+
+def updateChangelog () :
+
+    queryString = """
+    {
+    repository(owner: "BabylonJS", name: "Exporters") {
+        pullRequests(first:25, states:MERGED, labels:"3dsmax", orderBy:{field:UPDATED_AT, direction:DESC}) {
+        nodes {
+            updatedAt,
+            closedAt,
+            number,
+            title,
+            labels(first:10) {
+            edges {
+                node {
+                name
+                }
+            }
+            }
+        }
+        }
+    }
+    }
+    """
+    query = {'query': queryString.replace('\n', ' ')}
+    headers = {'Authorization': 'token ' + accessToken,
+            'Content-Type': 'application/json'}
+
+    response = requests.post(
+        'https://api.github.com/graphql', headers=headers, json=query)
+
+    if (json.loads(response.text)['message']) :
+        print(" ==> /!\\ Error when trying to reach the Github API : {0} \n".format(json.loads(response.text)['message']))
+        return
+
+    data = json.loads(response.text)['data']['repository']['pullRequests']['nodes']
+
+    # Get last version date
+    with open('CHANGELOG.md', 'r') as file_Changelog:
+        lineIndex = 0
+        for line in reversed(file_Changelog.readlines()):
+            lineIndex += 1
+            if line.find('### (2') != -1:
+                firstOcc = line.find('(')
+                lastOcc = line.find(')', firstOcc + 1)
+                lastVersionTime = line[firstOcc + 1: lastOcc]
+                break
+    file_Changelog.close()
+
+    # Then write PR titles in the Changelog
+    list_bug = []
+    list_enhancement = []
+    with open('CHANGELOG.md', 'a') as file_Changelog:
+        file_Changelog.write("\n## v" + Max2BabylonVersion)
+        file_Changelog.write("\n### ({0})".format(currentVersionTime))
+
+        for row in data:
+            isYounger = (lastVersionTime < row['closedAt'].replace(
+                'T', ' ').replace('Z', ''))
+            if isYounger:
+                for label in row['labels']['edges']:
+                    if label['node']['name'] == 'bug':
+                        list_bug.append(row)
+                    elif label['node']['name'] == 'enhancement':
+                        list_enhancement.append(row)
+
+        if len(list_enhancement) > 0:
+            file_Changelog.write("\n**Implemented Changes**")
+            for row in list_enhancement:
+                file_Changelog.write(
+                    "\n- {0} (https://github.com/BabylonJS/Exporters/pull/{1})".format(row['title'], row['number']))
+                file_Changelog.write('\n')
+
+        if len(list_bug) > 0:
+            file_Changelog.write("\n**Fixed Bugs**")
+            for row in list_bug:
+                file_Changelog.write(
+                    "\n- {0} (https://github.com/BabylonJS/Exporters/pull/{1})".format(row['title'], row['number']))
+                file_Changelog.write('\n')
+
+    file_Changelog.close()
+
+if (accessToken != ''): updateChangelog()
+else: print(" ==> /!\\ Changelog will not be completed \n")
+    
+
+# ---------- BUILD THE ZIP FILE FROM DLL ----------
 
 with zipfile.ZipFile(packageFolderPrefix + Max2BabylonPackagePrefix + Max2BabylonVersion + '.zip', 'w' ) as outputZip:
 

--- a/3ds Max/readme.md
+++ b/3ds Max/readme.md
@@ -13,3 +13,8 @@ Use "RaiseMessage/Warning" methods to see if your code is working
 * close all running 3dsmax instances.
 * rebuild project.
 * open 3dsmax again, run the exporter, the messages will be displayed in the exporter form.
+
+## Build package + autocomplete the Changelog (python script)
+Before using the Max2Babylon.py script, please install Python on your computer, and this package :
+- requests
+To do so, use the following command line : pip install [packageName]

--- a/Maya/CHANGELOG.md
+++ b/Maya/CHANGELOG.md
@@ -52,6 +52,7 @@ from the export interface
 (https://github.com/BabylonJS/Exporters/pull/479)
 
 ## v1.3.0
+### (2019-05-21 13:16:12)
 **Implemented Changes**
 - Added Animation Bake export toggle
 (https://github.com/BabylonJS/Exporters/issues/503)

--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -42,7 +42,7 @@ namespace Maya2Babylon
         /// </summary>
         private static List<string> defaultCameraNames = new List<string>(new string[] { "persp", "top", "front", "side" });
 
-        public static string exporterVersion = "1.3.0";
+        public static string exporterVersion = "1.3.1";
 
         /// <summary>
         /// Export to file

--- a/Maya/Maya2Babylon_Package.py
+++ b/Maya/Maya2Babylon_Package.py
@@ -1,6 +1,13 @@
+# BEFORE USING THIS SCRIPT, PLEASE MAKE SURE PYTHON AND THE PACKAGES LISTED IN THE README.MD ARE INSTALLED.
+
+# ---------- IMPORTS ----------
 import os
 import zipfile
 import shutil
+import json     # Changelog
+import requests  # Changelog
+import datetime  # Changelog
+
 
 versions = ['2017-2018', '2019']
 projectFolderPrefix = './'
@@ -8,14 +15,133 @@ buildPathPrefix = 'bin/Release/'
 
 packageFolderPrefix = './'
 Maya2BabylonPackagePrefix = 'Maya2Babylon-'
-Maya2BabylonVersion = '1.3.0'
 
-with zipfile.ZipFile(packageFolderPrefix + Maya2BabylonPackagePrefix + Maya2BabylonVersion + '.zip', 'w' ) as outputZip:
+currentVersionTime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+lastVersionTime = ''
+
+
+# ---------- EXPORTER VERSION ----------
+# Retrieved for the "Exporter/BabylonExporter.cs" file
+
+Maya2BabylonVersion = ''
+with open('Exporter/BabylonExporter.cs', 'r') as file_BabylonExporterCS:
+    lineIndex = 0
+    for line in file_BabylonExporterCS:
+        lineIndex += 1
+        if line.find('exporterVersion = "') != -1:
+            firstOcc = line.find('"')
+            lastOcc = line.find('"', firstOcc + 1)
+            Maya2BabylonVersion = line[firstOcc + 1: lastOcc]
+            break
+file_BabylonExporterCS.close()
+# Be sure that the version has been found. Otherwise, raise a Value Error
+if (Maya2BabylonVersion == ''):
+    raise ValueError(
+        "Impossible to fine line with 'string exporterVersion = \"' in the BabylonExporter.cs file")
+
+
+# ---------- UPDATING THE CHANGELOG.MD ----------
+
+# Get informations from the repo
+print("Please, enter your Github Access Token.")
+print("See the readme.md for more informations at ## Build package")
+print("Leave blank and press enter if you don't want to fill the Changelog")
+accessToken = str(input("Access Token : "))
+
+def updateChangelog () :
+
+    queryString = """
+    {
+    repository(owner: "BabylonJS", name: "Exporters") {
+        pullRequests(first:25, states:MERGED, labels:"maya", orderBy:{field:UPDATED_AT, direction:DESC}) {
+        nodes {
+            updatedAt,
+            closedAt,
+            number,
+            title,
+            labels(first:10) {
+            edges {
+                node {
+                name
+                }
+            }
+            }
+        }
+        }
+    }
+    }
+    """
+    query = {'query': queryString.replace('\n', ' ')}
+    headers = {'Authorization': 'token ' + accessToken,
+            'Content-Type': 'application/json'}
+
+    response = requests.post(
+        'https://api.github.com/graphql', headers=headers, json=query)
+
+    if (json.loads(response.text)['message']) :
+        print(" ==> /!\\ Error when trying to reach the Github API : {0} \n".format(json.loads(response.text)['message']))
+        return
+
+    data = json.loads(response.text)['data']['repository']['pullRequests']['nodes']
+
+    # Get last version date
+    with open('CHANGELOG.md', 'r') as file_Changelog:
+        lineIndex = 0
+        for line in reversed(file_Changelog.readlines()):
+            lineIndex += 1
+            if line.find('### (2') != -1:
+                firstOcc = line.find('(')
+                lastOcc = line.find(')', firstOcc + 1)
+                lastVersionTime = line[firstOcc + 1: lastOcc]
+                break
+    file_Changelog.close()
+
+    # Then write PR titles in the Changelog
+    list_bug = []
+    list_enhancement = []
+    with open('CHANGELOG.md', 'a') as file_Changelog:
+        file_Changelog.write("\n## v" + Maya2BabylonVersion)
+        file_Changelog.write("\n### ({0})".format(currentVersionTime))
+
+        for row in data:
+            isYounger = (lastVersionTime < row['closedAt'].replace(
+                'T', ' ').replace('Z', ''))
+            if isYounger:
+                for label in row['labels']['edges']:
+                    if label['node']['name'] == 'bug':
+                        list_bug.append(row)
+                    elif label['node']['name'] == 'enhancement':
+                        list_enhancement.append(row)
+
+        if len(list_enhancement) > 0:
+            file_Changelog.write("\n**Implemented Changes**")
+            for row in list_enhancement:
+                file_Changelog.write(
+                    "\n- {0} (https://github.com/BabylonJS/Exporters/pull/{1})".format(row['title'], row['number']))
+                file_Changelog.write('\n')
+
+        if len(list_bug) > 0:
+            file_Changelog.write("\n**Fixed Bugs**")
+            for row in list_bug:
+                file_Changelog.write(
+                    "\n- {0} (https://github.com/BabylonJS/Exporters/pull/{1})".format(row['title'], row['number']))
+                file_Changelog.write('\n')
+
+    file_Changelog.close()
+
+if (accessToken != ''): updateChangelog()
+else: print(" ==> /!\\ Changelog will not be completed \n")
+
+
+# ---------- BUILD THE ZIP FILE FROM DLL ----------
+
+with zipfile.ZipFile(packageFolderPrefix + Maya2BabylonPackagePrefix + Maya2BabylonVersion + '.zip', 'w') as outputZip:
 
     for version in versions:
         # get file paths
         buildPath = projectFolderPrefix + buildPathPrefix + version + '/'
-        buildDlls = [ dll for dll in os.listdir(buildPath) if dll.endswith('.dll')]
+        buildDlls = [dll for dll in os.listdir(
+            buildPath) if dll.endswith('.dll')]
 
         packagePath = version + '/'
         # copy bins to publish location

--- a/Maya/Maya2Babylon_Package.py
+++ b/Maya/Maya2Babylon_Package.py
@@ -78,14 +78,14 @@ def updateChangelog () :
     response = requests.post(
         'https://api.github.com/graphql', headers=headers, json=query)
 
-    if (json.loads(response.text)['message']) :
+    if ('message' in json.loads(response.text)) :
         print(" ==> /!\\ Error when trying to reach the Github API : {0} \n".format(json.loads(response.text)['message']))
         return
 
     data = json.loads(response.text)['data']['repository']['pullRequests']['nodes']
 
     # Get last version date
-    with open('CHANGELOG.md', 'r') as file_Changelog:
+    with open('{0}CHANGELOG.md'.format(packageFolderPrefix), 'r') as file_Changelog:
         lineIndex = 0
         for line in reversed(file_Changelog.readlines()):
             lineIndex += 1
@@ -99,7 +99,7 @@ def updateChangelog () :
     # Then write PR titles in the Changelog
     list_bug = []
     list_enhancement = []
-    with open('CHANGELOG.md', 'a') as file_Changelog:
+    with open('{0}CHANGELOG.md'.format(packageFolderPrefix), 'a') as file_Changelog:
         file_Changelog.write("\n## v" + Maya2BabylonVersion)
         file_Changelog.write("\n### ({0})".format(currentVersionTime))
 

--- a/Maya/readme.md
+++ b/Maya/readme.md
@@ -1,4 +1,17 @@
-Maya exporter
-====================
+Maya to Babylon.js exporter
+==============================
 
 Documentation: http://doc.babylonjs.com/resources/maya
+
+# How to contribute:
+## Requirements:
+* Install Visual Studio (community editon works)
+* Install Maya.
+
+## Develop:
+-
+
+## Build package + autocomplete the Changelog (python script)
+Before using the Max2Babylon.py script, please install Python on your computer, and this package :
+- requests
+To do so, use the following command line : pip install [packageName]


### PR DESCRIPTION
Python script for Changelog auto-completion, retrieving datas from the Github.

- Changelog : Last version date added (needed for auto completion)
- Readme : Explaination added
- BabylonExporter.cs : Version number incremented by 0.1 for testing purpose

+ Merge from official repo in mine