### PR TITLE
Fix _getSpecialTexmap null reference exception

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -513,6 +513,12 @@ namespace Max2Babylon
 
         private ITexmap _getSpecialTexmap(ITexmap texMap, out float amount)
         {
+            if (texMap == null)
+            {
+                amount = 0.0f;
+                return null;
+            }
+
             if (texMap.ClassName == "Normal Bump")
             {
                 var block = texMap.GetParamBlockByID(0);        // General Block


### PR DESCRIPTION
Addressing regression introduced via #472. _getSpecialTexmap can dereference a null texMap if the material lacks a diffuse/specular/normal/specular map. Adding a null check in _getSpecialTexmap should fix this.