### PR TITLE
Fix texture transform calculation, Update Babylon texture export message

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -779,10 +779,11 @@ namespace Max2Babylon
                 babylonTexture.vScale *= -1; // Need to invert Y-axis for DDS texture
             }
 
-            // TODO - rotation and scale
-            if (babylonTexture.wAng != 0f && (babylonTexture.uScale != 1f || babylonTexture.vScale != 1f))
+            if (babylonTexture.wAng != 0f 
+                && (babylonTexture.uScale != 1f || babylonTexture.vScale != 1f) 
+                && (Math.Abs(babylonTexture.uScale) - Math.Abs(babylonTexture.vScale)) > float.Epsilon)
             {
-                RaiseWarning("Rotation and tiling (scale) on a texture are only supported separatly. You can use the map UV of the mesh for those transformation.", 3);
+                RaiseWarning("Rotation and non-uniform tiling (scale) on a texture is not supported as it will cause texture shearing. You can use the map UV of the mesh for those transformations.", 3);
             }
 
 

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -755,11 +755,14 @@ namespace Max2Babylon
 
             var offset = new BabylonVector3(babylonTexture.uOffset, -babylonTexture.vOffset, 0);
             var scale = new BabylonVector3(babylonTexture.uScale, babylonTexture.vScale, 1);
-            var rotation = new BabylonQuaternion();
+            var rotationEuler = new BabylonVector3(uvGen.GetUAng(0), uvGen.GetVAng(0), uvGen.GetWAng(0));
+            var rotation = BabylonQuaternion.FromEulerAngles(rotationEuler.X, rotationEuler.Y, rotationEuler.Z);
             var pivotCenter = new BabylonVector3(-0.5f, -0.5f, 0);
             var transformMatrix = Tools.ComputeTextureTransformMatrix(pivotCenter, offset, rotation, scale);
 
             transformMatrix.decompose(scale, rotation, offset);
+            var texTransformRotationEuler = rotation.toEulerAngles();
+
             babylonTexture.uOffset = -offset.X;
             babylonTexture.vOffset = -offset.Y;
             babylonTexture.uScale = scale.X;
@@ -767,16 +770,14 @@ namespace Max2Babylon
             babylonTexture.uRotationCenter = 0.0f;
             babylonTexture.vRotationCenter = 0.0f;
             babylonTexture.invertY = false;
+            babylonTexture.uAng = texTransformRotationEuler.X;
+            babylonTexture.vAng = texTransformRotationEuler.Y;
+            babylonTexture.wAng = texTransformRotationEuler.Z;
 
             if (Path.GetExtension(babylonTexture.name).ToLower() == ".dds")
             {
                 babylonTexture.vScale *= -1; // Need to invert Y-axis for DDS texture
             }
-
-            babylonTexture.uAng = uvGen.GetUAng(0);
-            babylonTexture.vAng = uvGen.GetVAng(0);
-            babylonTexture.wAng = uvGen.GetWAng(0);
-
 
             // TODO - rotation and scale
             if (babylonTexture.wAng != 0f && (babylonTexture.uScale != 1f || babylonTexture.vScale != 1f))

--- a/SharedProjects/BabylonExport.Entities/BabylonQuaternion.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonQuaternion.cs
@@ -65,7 +65,41 @@ namespace BabylonExport.Entities
             return result;
         }
 
-        public override string ToString()
+        public static BabylonQuaternion FromEulerAngles(float x, float y, float z)
+        {
+            var q = new BabylonQuaternion();
+            BabylonQuaternion.RotationYawPitchRollToRef(y, x, z, q);
+            return q;
+        }
+
+        /**
+         * Creates a new rotation from the given Euler float angles (y, x, z) and stores it in the target quaternion
+         * @param yaw defines the rotation around Y axis
+         * @param pitch defines the rotation around X axis
+         * @param roll defines the rotation around Z axis
+         * @param result defines the target quaternion
+         */
+        public static void RotationYawPitchRollToRef(float yaw, float pitch, float roll, BabylonQuaternion result)
+        {
+            // Produces a quaternion from Euler angles in the z-y-x orientation (Tait-Bryan angles)
+            var halfRoll = roll * 0.5;
+            var halfPitch = pitch * 0.5;
+            var halfYaw = yaw * 0.5;
+
+            var sinRoll = Math.Sin(halfRoll);
+            var cosRoll = Math.Cos(halfRoll);
+            var sinPitch = Math.Sin(halfPitch);
+            var cosPitch = Math.Cos(halfPitch);
+            var sinYaw = Math.Sin(halfYaw);
+            var cosYaw = Math.Cos(halfYaw);
+
+            result.X = (float)((cosYaw* sinPitch * cosRoll) + (sinYaw* cosPitch * sinRoll));
+            result.Y = (float)((sinYaw* cosPitch * cosRoll) - (cosYaw* sinPitch * sinRoll));
+            result.Z = (float)((cosYaw* cosPitch * sinRoll) - (sinYaw* sinPitch * cosRoll));
+            result.W = (float)((cosYaw* cosPitch * cosRoll) + (sinYaw* sinPitch * sinRoll));
+        }
+
+    public override string ToString()
         {
             return "{ X=" + X + ", Y=" + Y + ", Z=" + Z + ", W=" + W + " }";
         }


### PR DESCRIPTION
This pull request fixes the texture transform calculation, which previously applied rotation after calculating a texture transform with rotation and scaling, causing inaccurate texture transform components when the transform is decomposed.

This change correctly calculates a rotation quaternion when computing the transform matrix.

This also changes the export warning to reflect the limitations of the current KHR_texture_transform spec.