### PR TITLE
Make baked animations get excluded in export if they aren't relevant within group frame range.

### DIFF
--- a/Maya/Exporter/BabylonExporter.GLTFExporter.Animation.cs
+++ b/Maya/Exporter/BabylonExporter.GLTFExporter.Animation.cs
@@ -158,12 +158,12 @@ namespace Maya2Babylon
                 {
                     // Filter animation keys to only keep frames between start and end
                     List<BabylonAnimationKey> keysInRangeFull = babylonAnimation.keysFull.FindAll(babylonAnimationKey => babylonAnimationKey.frame >= startFrame && babylonAnimationKey.frame <= endFrame);
-                    
+
                     // Optimization process always keeps first and last frames
                     OptimizeAnimations(keysInRangeFull, true);
                     bool keysInRangeAreRelevant = IsAnimationKeysRelevant(keysInRangeFull, babylonAnimation.property);
 
-                    // if we are baking the animation frames, then do a less efficient check against all frames in the scene for this animation channel
+                    // if we are baking the animation frames, then do a less efficient check against all frames in the scene for this animation channel if the first check fails.
                     if (!keysInRangeAreRelevant && _bakeAnimationFrames)
                     {
                         List<BabylonAnimationKey> optimizedKeysFull = new List<BabylonAnimationKey>(babylonAnimation.keysFull);
@@ -172,7 +172,7 @@ namespace Maya2Babylon
                     }
 
                     // If we have any significant animation keys in this channel
-                    // (or if we are baking the animation track and have any significant animation keys in the whole track)
+                    // (or if we are baking the animation track and have any relevant (non-identity) animation keys in the whole track)
                     // then add the optimized keys in range to the animation track
                     if (keysInRangeAreRelevant)
                     {


### PR DESCRIPTION
Fix for #549, for GLTF export add additional animation relevance check against entire animation channel if the initial check against the frame range isn't relevant

