### PR TITLE
Update skinning and morph target warning message

### DIFF
--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -540,7 +540,7 @@ namespace Maya2Babylon
 
                 if (_exportSkin && mFnSkinCluster != null)
                 {
-                    RaiseWarning("A mesh with both skin and morph target is not fully supported.", 3);
+                    RaiseWarning("A mesh with both skinning and morph target is not fully supported. Please set the playhead at the frame you want to choose as the bind pose before exporting.", 3);
                 }
 
                 if(blendShapeDeformers.Count > 1)


### PR DESCRIPTION
to improve the UX, update the warning message when a mesh is to be exported with skinning and morph target info to set the playhead to the proper frame so that the targets are exported properly.