### PR TITLE
[3dsMax][C#][PostBuild] Handle using Max 2016 with Max 2015 exporter version

### DIFF
--- a/3ds Max/Max2Babylon/OnPostBuild.bat
+++ b/3ds Max/Max2Babylon/OnPostBuild.bat
@@ -3,9 +3,15 @@ SETLOCAL enabledelayedexpansion
 
 
 SET max_version=%2
+SET exporter_version=%max_version%
 SET max_location=!ADSK_3DSMAX_x64_%max_version%!
 
-SET source_dir="%~dp0%max_version%\bin\%1"
+IF %exporter_version%==2016 SET exporter_version=2015
+
+ECHO "Max version is %max_version%"
+ECHO "Exporter version is %exporter_version%"
+
+SET source_dir="%~dp0%exporter_version%\bin\%1"
 ECHO %source_dir%
 
 IF "%max_location%"=="" (


### PR DESCRIPTION
Still requires the developer to change the postbuild event to pass 2016 to the script instead of 2015, but the rest is handled this way