### PR TITLE
Fix Maya rotation animation quaternion conversion

### DIFF
--- a/Maya/Exporter/BabylonExporter.Animation.cs
+++ b/Maya/Exporter/BabylonExporter.Animation.cs
@@ -225,9 +225,10 @@ namespace Maya2Babylon
             Dictionary<string, float> defaultValues = new Dictionary<string, float>();
             float[] position = null;
             float[] rotationQuaternion = null;
+            BabylonVector3.EulerRotationOrder rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
             float[] rotation = null;
             float[] scaling = null;
-            GetTransform(transform, ref position, ref rotationQuaternion, ref rotation, ref scaling); // coordinate system already switched
+            GetTransform(transform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling); // coordinate system already switched
             defaultValues.Add("translateX", position[0]);
             defaultValues.Add("translateY", position[1]);
             defaultValues.Add("translateZ", position[2]);
@@ -306,7 +307,7 @@ namespace Maya2Babylon
                     {
                         BabylonVector3 eulerAngles = BabylonVector3.FromArray(babylonAnimationKey.values);
                         BabylonVector3 eulerAnglesRadians = eulerAngles * (float)(Math.PI / 180);
-                        BabylonQuaternion quaternionAngles = eulerAnglesRadians.toQuaternion();
+                        BabylonQuaternion quaternionAngles = eulerAnglesRadians.toQuaternion(rotationOrder);
                         babylonAnimationKey.values = quaternionAngles.ToArray();
                     }
                 }

--- a/Maya/Exporter/BabylonExporter.Camera.cs
+++ b/Maya/Exporter/BabylonExporter.Camera.cs
@@ -91,13 +91,18 @@ namespace Maya2Babylon
             float[] rotationQuaternion = null;
             float[] rotation = null;
             float[] scaling = null;
-            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref scaling);
+            var rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
+            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling);
             babylonCamera.position = position;
             if (_exportQuaternionsInsteadOfEulers)
             {
                 babylonCamera.rotationQuaternion = rotationQuaternion;
             }
-            babylonCamera.rotation = rotation;
+            else
+            {
+                babylonCamera.rotation = rotation;
+            }
+            
 
             // Field of view of babylon is the vertical one
             babylonCamera.fov = (float)mFnCamera.verticalFieldOfView;

--- a/Maya/Exporter/BabylonExporter.GLTFExporter.cs
+++ b/Maya/Exporter/BabylonExporter.GLTFExporter.cs
@@ -512,7 +512,8 @@ namespace Maya2Babylon
                         Y = babylonNode.rotation[1],
                         Z = babylonNode.rotation[2]
                     };
-                    gltfNode.rotation = rotationVector3.toQuaternion().ToArray();
+                    // babylon euler rotation order is YXZ
+                    gltfNode.rotation = rotationVector3.toQuaternion(BabylonVector3.EulerRotationOrder.YXZ).ToArray();
                 }
             }
             else // Light

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -967,7 +967,8 @@ namespace Maya2Babylon
             float[] rotationQuaternion = null;
             float[] rotation = null;
             float[] scaling = null;
-            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref scaling);
+            BabylonVector3.EulerRotationOrder rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
+            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling);
 
             babylonAbstractMesh.position = position;
             if (_exportQuaternionsInsteadOfEulers)

--- a/Maya/Exporter/BabylonExporter.Node.cs
+++ b/Maya/Exporter/BabylonExporter.Node.cs
@@ -1,6 +1,8 @@
 ﻿using Autodesk.Maya.OpenMaya;
 using BabylonExport.Entities;
+using System;
 using System.Collections.Generic;
+using Utilities;
 
 namespace Maya2Babylon
 {
@@ -58,9 +60,12 @@ namespace Maya2Babylon
             }
         }
 
-        private void GetTransform(MFnTransform mFnTransform, ref float[] position, ref float[] rotationQuaternion, ref float[] rotation, ref float[] scaling)
+        private void GetTransform(MFnTransform mFnTransform, ref float[] position, ref float[] rotationQuaternion, ref float[] rotation, ref BabylonVector3.EulerRotationOrder rotationOrder, ref float[] scaling)
         {
             var transformationMatrix = new MTransformationMatrix(mFnTransform.transformationMatrix);
+            var mayaRotationOrder = 0;
+            MGlobal.executeCommand($"getAttr {mFnTransform.fullPathName}.rotateOrder", out mayaRotationOrder);
+            rotationOrder = Tools.ConvertMayaRotationOrder((MEulerRotation.RotationOrder)mayaRotationOrder);
 
             position = transformationMatrix.getTranslation();
             rotationQuaternion = transformationMatrix.getRotationQuaternion();
@@ -73,6 +78,7 @@ namespace Maya2Babylon
             rotationQuaternion[1] *= -1;
             rotation[0] *= -1;
             rotation[1] *= -1;
+            rotationOrder = Tools.InvertRotationOrder(rotationOrder);
         }
 
         private void GetTransform(MFnTransform mFnTransform, ref float[] position)

--- a/Maya/Tools/Tools.cs
+++ b/Maya/Tools/Tools.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using BabylonExport.Entities;
 
 namespace Maya2Babylon
 {
@@ -17,6 +18,47 @@ namespace Maya2Babylon
         public static float Lerp(float min, float max, float t)
         {
             return min + (max - min) * t;
+        }
+
+        public static BabylonVector3.EulerRotationOrder ConvertMayaRotationOrder(MEulerRotation.RotationOrder mayaRotationOrder)
+        {
+            // http://download.autodesk.com/us/maya/2010help/api/class_m_transformation_matrix.html#adbf54177dae3a2015e51cd6bde8941e
+            switch (mayaRotationOrder)
+            {
+                case MEulerRotation.RotationOrder.kXYZ:
+                default:
+                    return BabylonVector3.EulerRotationOrder.XYZ;
+                case MEulerRotation.RotationOrder.kYZX:
+                    return BabylonVector3.EulerRotationOrder.YZX;
+                case MEulerRotation.RotationOrder.kZXY:
+                    return BabylonVector3.EulerRotationOrder.ZXY;
+                case MEulerRotation.RotationOrder.kXZY:
+                    return BabylonVector3.EulerRotationOrder.XZY;
+                case MEulerRotation.RotationOrder.kYXZ:
+                    return BabylonVector3.EulerRotationOrder.YXZ;
+                case MEulerRotation.RotationOrder.kZYX:
+                    return BabylonVector3.EulerRotationOrder.ZYX;
+            }
+        }
+
+        public static BabylonVector3.EulerRotationOrder InvertRotationOrder(BabylonVector3.EulerRotationOrder rotationOrder)
+        {
+            switch (rotationOrder)
+            {
+                case BabylonVector3.EulerRotationOrder.XYZ:
+                default:
+                    return BabylonVector3.EulerRotationOrder.ZYX;
+                case BabylonVector3.EulerRotationOrder.YZX:
+                    return BabylonVector3.EulerRotationOrder.XZY;
+                case BabylonVector3.EulerRotationOrder.ZXY:
+                    return BabylonVector3.EulerRotationOrder.YXZ;
+                case BabylonVector3.EulerRotationOrder.XZY:
+                    return BabylonVector3.EulerRotationOrder.YZX;
+                case BabylonVector3.EulerRotationOrder.YXZ:
+                    return BabylonVector3.EulerRotationOrder.ZXY;
+                case BabylonVector3.EulerRotationOrder.ZYX:
+                    return BabylonVector3.EulerRotationOrder.XYZ;
+            }
         }
 
         // -------------------------

--- a/SharedProjects/BabylonExport.Entities/BabylonVector3.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonVector3.cs
@@ -52,10 +52,74 @@ namespace BabylonExport.Entities
             return new BabylonVector3 { X = a.X * b, Y = a.Y * b, Z = a.Z * b };
         }
 
-        public BabylonQuaternion toQuaternion()
+        public enum EulerRotationOrder
         {
-            return RotationYawPitchRollToRefBabylon(Y, X, Z);
+            XYZ,
+            YZX,
+            ZXY,
+            XZY,
+            YXZ,
+            ZYX
         }
+
+        // https://www.mathworks.com/matlabcentral/fileexchange/20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors?s_tid=mwa_osa_a
+        // https://github.com/mrdoob/three.js/blob/09cfc67a3f52aeb4dd0009921d82396fd5dc5172/src/math/Quaternion.js#L199-L272
+
+        public BabylonQuaternion toQuaternion(EulerRotationOrder rotationOrder = EulerRotationOrder.XYZ)
+        {
+            BabylonQuaternion quaternion = new BabylonQuaternion();
+
+            var c1 = Math.Cos(0.5 * this.X);
+            var c2 = Math.Cos(0.5 * this.Y);
+            var c3 = Math.Cos(0.5 * this.Z);
+
+            var s1 = Math.Sin(0.5 * this.X);
+            var s2 = Math.Sin(0.5 * this.Y);
+            var s3 = Math.Sin(0.5 * this.Z);
+
+            switch (rotationOrder)
+            {
+                case EulerRotationOrder.XYZ:
+                    quaternion.X = (float)(s1 * c2 * c3 + c1 * s2 * s3);
+                    quaternion.Y = (float)(c1 * s2 * c3 - s1 * c2 * s3);
+                    quaternion.Z = (float)(c1 * c2 * s3 + s1 * s2 * c3);
+                    quaternion.W = (float)(c1 * c2 * c3 - s1 * s2 * s3);
+                    break;
+                case EulerRotationOrder.YZX:
+                    quaternion.X = (float)(s1 * c2 * c3 + c1 * s2 * s3);
+                    quaternion.Y = (float)(c1 * s2 * c3 + s1 * c2 * s3);
+                    quaternion.Z = (float)(c1 * c2 * s3 - s1 * s2 * c3);
+                    quaternion.W = (float)(c1 * c2 * c3 - s1 * s2 * s3);
+                    break;
+                case EulerRotationOrder.ZXY:
+                    quaternion.X = (float)(s1 * c2 * c3 - c1 * s2 * s3);
+                    quaternion.Y = (float)(c1 * s2 * c3 + s1 * c2 * s3);
+                    quaternion.Z = (float)(c1 * c2 * s3 + s1 * s2 * c3);
+                    quaternion.W = (float)(c1 * c2 * c3 - s1 * s2 * s3);
+                    break;
+                case EulerRotationOrder.XZY:
+                    quaternion.X = (float)(s1 * c2 * c3 - c1 * s2 * s3);
+                    quaternion.Y = (float)(c1 * s2 * c3 - s1 * c2 * s3);
+                    quaternion.Z = (float)(c1 * c2 * s3 + s1 * s2 * c3);
+                    quaternion.W = (float)(c1 * c2 * c3 + s1 * s2 * s3);
+                    break;
+                case EulerRotationOrder.YXZ:
+                    quaternion.X = (float)(s1 * c2 * c3 + c1 * s2 * s3);
+                    quaternion.Y = (float)(c1 * s2 * c3 - s1 * c2 * s3);
+                    quaternion.Z = (float)(c1 * c2 * s3 - s1 * s2 * c3);
+                    quaternion.W = (float)(c1 * c2 * c3 + s1 * s2 * s3);
+                    break;
+                case EulerRotationOrder.ZYX:
+                    quaternion.X = (float)(s1 * c2 * c3 - c1 * s2 * s3);
+                    quaternion.Y = (float)(c1 * s2 * c3 + s1 * c2 * s3);
+                    quaternion.Z = (float)(c1 * c2 * s3 - s1 * s2 * c3);
+                    quaternion.W = (float)(c1 * c2 * c3 + s1 * s2 * s3);
+                    break;
+            }
+            return quaternion;
+        }
+
+        /**
 
         /**
          * (Copy pasted from babylon)

--- a/SharedProjects/BabylonExport.Entities/BabylonVector3.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonVector3.cs
@@ -120,34 +120,6 @@ namespace BabylonExport.Entities
         }
 
         /**
-
-        /**
-         * (Copy pasted from babylon)
-         * Sets the passed quaternion "result" from the passed float Euler angles (radians) (y, x, z).
-         */
-        private BabylonQuaternion RotationYawPitchRollToRefBabylon(float yaw, float pitch, float roll)
-        {
-            // Produces a quaternion from Euler angles in the z-y-x orientation (Tait-Bryan angles)
-            var halfRoll = roll * 0.5;
-            var halfPitch = pitch * 0.5;
-            var halfYaw = yaw * 0.5;
-
-            var sinRoll = Math.Sin(halfRoll);
-            var cosRoll = Math.Cos(halfRoll);
-            var sinPitch = Math.Sin(halfPitch);
-            var cosPitch = Math.Cos(halfPitch);
-            var sinYaw = Math.Sin(halfYaw);
-            var cosYaw = Math.Cos(halfYaw);
-
-            var result = new BabylonQuaternion();
-            result.X = (float)((cosYaw * sinPitch * cosRoll) + (sinYaw * cosPitch * sinRoll));
-            result.Y = (float)((sinYaw * cosPitch * cosRoll) - (cosYaw * sinPitch * sinRoll));
-            result.Z = (float)((cosYaw * cosPitch * sinRoll) - (sinYaw * sinPitch * cosRoll));
-            result.W = (float)((cosYaw * cosPitch * cosRoll) + (sinYaw * sinPitch * sinRoll));
-            return result;
-        }
-
-        /**
          * Returns a new Vector3 set from the index "countOffset" x 3 of the passed array.
          */
         public static BabylonVector3 FromArray(float[] array, int countOffset = 0)


### PR DESCRIPTION
This is intended to fix an issue where maya rotation animation keyframes are not accurately exported to Babylon. 

Reimplemented EulerAngle->Quaternion conversion to work with all 123 euler rotation sequences that are supported by Maya. Modified the animation keyframe export process to properly reverse rotation order when changing coordinate system from RHR to LHR.