### PR TITLE
Fix 3dsMax glTF skeletal animation export.

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -309,7 +309,7 @@ namespace Max2Babylon
                 // create the bone
                 BabylonBone bone = new BabylonBone()
                 {
-                    id = isBabylonExported ? node.MaxNode.GetGuid().ToString()+"-bone" : node.MaxNode.GetGuid().ToString(), // the suffix "-bone" is added in babylon export format to assure the uniqueness of IDs
+                    id = node.MaxNode.GetGuid().ToString() + "-bone",// the suffix "-bone" is added in babylon export format to assure the uniqueness of IDs
                     name = node.Name,
                     index = nodeIndices.IndexOf(node.NodeID),
                     parentBoneIndex = parentIndex,


### PR DESCRIPTION
Fix for issue where 3dsMax skeletal animation groups are incomplete.
When we query for animated bones via BabylonExporter::ExportAnimationGroups, we query bones using the unique bone identifier of "{bone-node-guid}-bone" which allows .babylon format to identify bones separately from their nodes. 

This naming convention isn't used for gltf export, causing our refactor to expose this difference in behavior, and cauising our animation group to miss some bone animations. 

This was fixed by removing the divergence in behavior between the code paths, using the .babylon bone identifier notation for both export formats.

addressing #571 