### PR TITLE
Fix MaxScriptManager::Export() NullReference exception

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -112,7 +112,11 @@ namespace Max2Babylon
             }
 
             this.exportParameters = exportParameters;
-            var exportNode = (exportParameters as MaxExportParameters).exportNode;
+            IINode exportNode = null;
+            if (exportParameters is MaxExportParameters)
+            {
+                exportNode = (exportParameters as MaxExportParameters).exportNode;
+            }
 
             var gameConversionManger = Loader.Global.ConversionManager;
             gameConversionManger.CoordSystem = Autodesk.Max.IGameConversionManager.CoordSystem.D3d;

--- a/3ds Max/Max2Babylon/MaxScriptManager.cs
+++ b/3ds Max/Max2Babylon/MaxScriptManager.cs
@@ -25,7 +25,7 @@ namespace Max2Babylon
             Export(InitParameters(outputPath));
         }
 
-        public static void Export(ExportParameters exportParameters)
+        public static void Export(MaxExportParameters exportParameters)
         {
             if (Loader.Class_ID == null)
             {
@@ -65,11 +65,11 @@ namespace Max2Babylon
 
 
         //leave the possibility to do get the outputh path from the babylon exporter with all the settings as presaved
-        public static ExportParameters InitParameters(string outputPath)
+        public static MaxExportParameters InitParameters(string outputPath)
         {
             long txtQuality = 100;
             float scaleFactor = 1f;
-            ExportParameters exportParameters = new ExportParameters();
+            MaxExportParameters exportParameters = new MaxExportParameters();
             exportParameters.outputPath = outputPath;
             exportParameters.outputFormat = Path.GetExtension(outputPath)?.Substring(1);
             exportParameters.textureFolder = Loader.Core.RootNode.GetStringProperty("textureFolderPathProperty", string.Empty);


### PR DESCRIPTION
Fixing null reference exception when executing MaxScriptManager. Changed MaxScriptManager ExportParameters to use MaxExportParameters structure.

Addressing #577 