### PR TITLE
Remove glTF export texture renaming

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
@@ -335,17 +335,13 @@ namespace Babylon2GLTF
                         //export textures
                         if (baseColorBitmap != null || babylonTexture.bitmap != null)
                         {
-                            var baseColorFileName = babylonMaterial.name + "_baseColor" + (isAlphaInTexture ? ".png" : ".jpg");
-                            baseColorFileName = baseColorFileName.Replace(":", "_");
-                            textureInfoBC = ExportBitmapTexture(gltf, babylonTexture, baseColorBitmap, baseColorFileName);
+                            textureInfoBC = ExportBitmapTexture(gltf, babylonTexture, baseColorBitmap);
                             gltfPbrMetallicRoughness.baseColorTexture = textureInfoBC;
                         }
 
                         if (isTextureOk(babylonStandardMaterial.specularTexture))
                         {
-                            var metallicRoughnessFileName = babylonMaterial.name + "_metallicRoughness" + ".jpg";
-                            metallicRoughnessFileName = metallicRoughnessFileName.Replace(":", "_");
-                            textureInfoMR = ExportBitmapTexture(gltf, babylonTexture, metallicRoughnessBitmap, metallicRoughnessFileName);
+                            textureInfoMR = ExportBitmapTexture(gltf, babylonTexture, metallicRoughnessBitmap);
                             gltfPbrMetallicRoughness.metallicRoughnessTexture = textureInfoMR;
                         }
 

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -324,8 +324,7 @@ namespace Babylon2GLTF
                 }
             }
 
-            var name = babylonMaterial.name + "_emissive.jpg";
-            var emissiveTextureInfo = ExportBitmapTexture(gltf, babylonTexture, emissivePremultipliedBitmap, name);
+            var emissiveTextureInfo = ExportBitmapTexture(gltf, babylonTexture, emissivePremultipliedBitmap);
 
             // Register the texture for optimisation
             RegisterEmissive(emissiveTextureInfo, babylonMaterial, defaultDiffuse, defaultEmissive);


### PR DESCRIPTION
As a result of refactoring via #566, I improperly took changes introduced via https://github.com/BabylonJS/Exporters/commit/f97c29c0b12ffbbf736fa19f765eb678f0dba75c into the shared exporter.

As a result, we rename our textures in the Babylon->glTF export, which can negatively affect an asset pipeline due to duplication of textures. 

This appears to be related to #571, where texture paths are broken in exported scene.

This PR removes texture renaming in glTF export, preserving the original texture name provided to the exporter.