### PR TITLE
Corrected links.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,12 @@ Babylon.js exporters
 
 [![Build Status](https://dev.azure.com/babylonjs/ContinousIntegration/_apis/build/status/Exporters%20CI?branchName=master)](https://dev.azure.com/babylonjs/ContinousIntegration/_build/latest?definitionId=3&branchName=master) [![Deployment Status](https://vsrm.dev.azure.com/babylonjs/_apis/public/Release/badge/243fb099-542d-4655-b246-4dfd67131bd4/1/1)](https://dev.azure.com/babylonjs/ContinousIntegration/_release?view=all&definitionId=1)
 
-Documentation for all exporters is available here: http://doc.babylonjs.com/exporters
+**Get the latest installer for our exporters here: https://github.com/BabylonJS/Exporters/releases**
+
+Documentation on the 3ds Max exporter is available here: https://doc.babylonjs.com/resources/3dsmax<br />
+Documentation for exporting from 3ds Max to glTF is available here: https://doc.babylonjs.com/resources/3dsmax_to_gltf
+
+Documentation on the Maya exporter is available here: https://doc.babylonjs.com/resources/maya<br />
+Documentation for exporting from Maya to glTF is available here: https://doc.babylonjs.com/resources/maya_to_gltf
 
 **Any questions?** Here is our official [forum](https://forum.babylonjs.com/).


### PR DESCRIPTION
The general exporter documentation link did not exist so I added links to general installer info and glTF specific info for both Max and Maya. I also placed a direct link to the releases page here in the doc as a backup path to our releases.