### PR TITLE
[3dsMax] Fix alphaTest attribute for standard material glTF export, add alphaCutoff control to babylon custom attributes.

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -266,6 +266,17 @@ namespace Max2Babylon
                     }
                 }
 
+                if (babylonMaterial.alpha != 1.0f || (babylonMaterial.diffuseTexture != null && babylonMaterial.diffuseTexture.hasAlpha) || babylonMaterial.opacityTexture != null)
+                {
+                    var alphaTestProperty = materialNode.IPropertyContainer.QueryProperty("BabylonAlphaTest");
+                    var alphaTestPercentProperty = materialNode.IPropertyContainer.QueryProperty("BabylonAlphaTestPercent");
+                    bool isAlphaTest = alphaTestProperty != null ? alphaTestProperty.GetBoolValue() : false;
+                    float alphaTestPercent = alphaTestPercentProperty != null ? alphaTestPercentProperty.GetFloatValue() : 0.5f; // default alpha test cutoff is 50%
+
+                    babylonMaterial.transparencyMode = isAlphaTest ? (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHATEST : (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHABLEND;
+                    babylonMaterial.alphaCutOff = alphaTestPercent;
+                }
+
                 // Constraints
                 if (babylonMaterial.diffuseTexture != null)
                 {
@@ -436,13 +447,15 @@ namespace Max2Babylon
                     babylonMaterial.emissiveTexture = ExportPBRTexture(materialNode, 17, babylonScene);
                 }
 
-
                 if (babylonMaterial.alpha != 1.0f || (babylonMaterial.baseTexture != null && babylonMaterial.baseTexture.hasAlpha))
                 {
                     var alphaTestProperty = materialNode.IPropertyContainer.QueryProperty("BabylonAlphaTest");
+                    var alphaTestPercentProperty = materialNode.IPropertyContainer.QueryProperty("BabylonAlphaTestPercent");
                     bool isAlphaTest = alphaTestProperty != null ? alphaTestProperty.GetBoolValue() : false;
+                    float alphaTestPercent = alphaTestPercentProperty != null ? alphaTestPercentProperty.GetFloatValue() : 0.5f; // default alpha test cutoff is 50%
 
                     babylonMaterial.transparencyMode = isAlphaTest ? (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHATEST : (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHABLEND;
+                    babylonMaterial.alphaCutOff = alphaTestPercent;
                 }
 
                 if (babylonMaterial.emissiveTexture != null)
@@ -623,7 +636,13 @@ namespace Max2Babylon
 
                 if (babylonMaterial.alpha != 1.0f || (babylonMaterial.baseTexture != null && babylonMaterial.baseTexture.hasAlpha))
                 {
-                    babylonMaterial.transparencyMode = (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHABLEND;
+                    var alphaTestProperty = materialNode.IPropertyContainer.QueryProperty("BabylonAlphaTest");
+                    var alphaTestPercentProperty = materialNode.IPropertyContainer.QueryProperty("BabylonAlphaTestPercent");
+                    bool isAlphaTest = alphaTestProperty != null ? alphaTestProperty.GetBoolValue() : false;
+                    float alphaTestPercent = alphaTestPercentProperty != null ? alphaTestPercentProperty.GetFloatValue() : 0.5f; // default alpha test cutoff is 50%
+
+                    babylonMaterial.transparencyMode = isAlphaTest ? (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHATEST : (int)BabylonPBRMetallicRoughnessMaterial.TransparencyMode.ALPHABLEND;
+                    babylonMaterial.alphaCutOff = alphaTestPercent;
                 }
 
                 if (babylonMaterial.metallicRoughnessTexture != null)

--- a/3ds Max/MaxScripts/BabylonMaterialAttributes.ms
+++ b/3ds Max/MaxScripts/BabylonMaterialAttributes.ms
@@ -1,16 +1,18 @@
 -- Create Babylon material attributes
 CAT_DEF = attributes Babylon_Attributes 
-version:0
+version:1
 (
 	Parameters main rollout:params
 	(
 		'babylonUnlit' Type:#BOOLEAN UI:'babylonUnlit' Default:False
 		'babylonAlphaTest' Type:#BOOLEAN UI:'babylonAlphaTest' Default:False
+		'babylonAlphaTestPercent' Type:#FLOAT UI:'babylonAlphaTestPercent' Default:0.50
 	)
 	Rollout Params "Babylon Attributes"
 	(
 		checkbox 'babylonUnlit' "Unlit" Width:70 Height:15 Align:#Left Offset:[0,0] Type:#BOOLEAN
 		checkbox 'babylonAlphaTest' "Alpha Test" Width:70 Height:15 Align:#Left Offset:[0,0] Type:#BOOLEAN
+		spinner 'babylonAlphaTestPercent' "Alpha Test Cutoff Percent" Width:140 Height:15 Align:#Left Offset:[0,0] Type:#FLOAT Range:[0,1.0, 0]
 	)
 )
 
@@ -25,9 +27,11 @@ for mat in scenematerials do
 		alreadyAdded = false;
 		for def in defs do
 		(
+			-- if attribute already exists, update the definition to use this version.
 			if def.name == #Babylon_Attributes then
 			(
-				alreadyAdded = true;	
+				alreadyAdded = true;
+				CustAttributes.redefine def CAT_DEF.source
 			)
 		)
 		

--- a/3ds Max/MaxScripts/BabylonMaterialAttributes.ms
+++ b/3ds Max/MaxScripts/BabylonMaterialAttributes.ms
@@ -20,6 +20,7 @@ version:1
 -- Add Babylon Attributes to all materials used in the scene
 for mat in scenematerials do
 (
+	print ("Adding attributes to " + mat.name)
 	defs = custAttributes.getDefs mat;
 	if defs != undefined then
 	(

--- a/SharedProjects/BabylonExport.Entities/BabylonMaterial.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMaterial.cs
@@ -23,6 +23,8 @@ namespace BabylonExport.Entities
         [DataMember]
         public int alphaMode { get; set; }
 
+
+
         public bool isUnlit = false;
 
         public BabylonMaterial(string id)

--- a/SharedProjects/BabylonExport.Entities/BabylonPBRMetallicRoughnessMaterial.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonPBRMetallicRoughnessMaterial.cs
@@ -77,7 +77,7 @@ namespace BabylonExport.Entities
             maxSimultaneousLights = 4;
             emissive = new[] { 0f, 0f, 0f };
             occlusionStrength = 1.0f;
-            alphaCutOff = 0.4f;
+            alphaCutOff = 0.5f;
             transparencyMode = (int)TransparencyMode.OPAQUE;
 
             clearCoat = new BabylonPBRClearCoat();

--- a/SharedProjects/BabylonExport.Entities/BabylonStandardMaterial.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonStandardMaterial.cs
@@ -82,6 +82,8 @@ namespace BabylonExport.Entities
 
         // Used for gltf
         public float selfIllum;
+        public int transparencyMode;
+        public float alphaCutOff;
 
         public BabylonStandardMaterial(string id) : base(id)
         {


### PR DESCRIPTION
Addressing #602  and #597, this PR proposes adding a float property to the "Babylon Attributes" material custom attribute container, and adds ability to redefine existing Babylon Attributes without data loss.

This PR also adds non-serialized transparencyMode and alphaCutoff fields to standard materials to persist to glTF export.