### PR TITLE
Changed vertex coordinate retrival to object space to fix precision l…

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -741,13 +741,14 @@ namespace Max2Babylon
             var vertex = new GlobalVertex
             {
                 BaseIndex = vertexIndex,
-                Position = mesh.GetVertex(vertexIndex, false), // world space
+                Position = mesh.GetVertex(vertexIndex, true), // retrieve in object space to keep precision
                 Normal = mesh.GetNormal((int)face.Norm[facePart], true) // object space (world space was somehow bugged for normal)
             };
             //System.Diagnostics.Debug.WriteLine("vertex normal: " + string.Join(", ", vertex.Normal.ToArray().Select(v => Math.Round(v, 3))));
+                       
 
-            // position (from world to local/node space)
-            vertex.Position = invertedWorldMatrix.PointTransform(vertex.Position);
+            // convert from object to local/node space
+            vertex.Position = offsetTM.PointTransform(vertex.Position);
 
             // normal (from object to local/node space)
             vertex.Normal = offsetTM.VectorTransform(vertex.Normal).Normalize;


### PR DESCRIPTION
Proposed fix for bug #608 
Changed vertex coordinate collection from world space to object space as the former resulted in precision loss in the export process.