### PR TITLE
Optimization

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
+++ b/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
@@ -228,7 +228,7 @@ namespace Max2Babylon
                 if (node != null)
                 {
                     string name = node.Name;
-                    string parentName =  Tools.GetINodeByGuid(nodeGuid).ParentNode.Name;
+                    string parentName = node.ParentNode.Name;
                     AnimationGroupNode nodeData = new AnimationGroupNode(nodeGuid, name, parentName);
                     AnimationGroupNodes.Add(nodeData);
                 }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -28,9 +28,9 @@ namespace Max2Babylon
                 };
 
                 // add animations of each nodes contained in the animGroup
-                foreach(Guid nodeGuid in animGroup.NodeGuids)
+                foreach (Guid guid in animGroup.NodeGuids)
                 {
-                    IINode maxNode = Loader.Core.RootNode.FindChildNode(nodeGuid);
+                    IINode maxNode = Tools.GetINodeByGuid(guid);
 
                     // node could have been deleted, silently ignore it
                     if (maxNode == null)
@@ -38,14 +38,14 @@ namespace Max2Babylon
 
 
                     // Helpers can be exported as dummies and as bones
-                    string nodeId = maxNode.GetGuid().ToString();
-                    string boneId = maxNode.GetGuid().ToString()+"-bone";   // the suffix "-bone" is added in babylon export format to assure the uniqueness of IDs
+                    string nodeId = guid.ToString();
+                    string boneId = guid.ToString()+"-bone";   // the suffix "-bone" is added in babylon export format to assure the uniqueness of IDs
 
 
                     // Node
                     BabylonNode node = null;
                     babylonScene.NodeMap.TryGetValue(nodeId, out node);
-                    if(node != null)
+                    if (node != null)
                     {
                         if (node.animations != null && node.animations.Length != 0)
                         {
@@ -76,14 +76,14 @@ namespace Max2Babylon
                     // bone
                     BabylonBone bone = null;
                     int index = 0;
-                    while(index < babylonScene.SkeletonsList.Count && bone == null)
+                    while (index < babylonScene.SkeletonsList.Count && bone == null)
                     {
                         BabylonSkeleton skel = babylonScene.SkeletonsList[index];
                         bone = skel.bones.FirstOrDefault(b => b.id == boneId);
                         index++;
                     }
 
-                    if(bone != null)
+                    if (bone != null)
                     {
                         if (bone.animation != null)
                         {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -216,8 +216,8 @@ namespace Max2Babylon
             RaiseMessage($"Exportation started: {fileExportString}", Color.Blue);
 
 #if DEBUG
-            var t1 = watch.ElapsedMilliseconds / 1000.0;
-            RaiseMessage(string.Format("Containers merged in {0:0.00}s", t1 ), Color.Blue);
+            var containersXrefMergeTime = watch.ElapsedMilliseconds / 1000.0;
+            RaiseMessage(string.Format("Containers and Xref  merged in {0:0.00}s", containersXrefMergeTime ), Color.Blue);
 #endif
 
             this.scaleFactor = Tools.GetScaleFactorToMeters();
@@ -573,8 +573,8 @@ namespace Max2Babylon
             }
 
 #if DEBUG
-            var t2 = watch.ElapsedMilliseconds / 1000.0 -t1;
-            RaiseMessage(string.Format("Noded exported in {0:0.00}s", t2), Color.Blue);
+            var nodesExportTime = watch.ElapsedMilliseconds / 1000.0 -containersXrefMergeTime;
+            RaiseMessage(string.Format("Noded exported in {0:0.00}s", nodesExportTime), Color.Blue);
 #endif
 
             // ----------------------------
@@ -584,8 +584,8 @@ namespace Max2Babylon
             // add animation groups to the scene
             babylonScene.animationGroups = ExportAnimationGroups(babylonScene);
 #if DEBUG
-            var t3 = watch.ElapsedMilliseconds / 1000.0 -t2;
-            RaiseMessage(string.Format("Animation groups exported in {0:0.00}s", t3), Color.Blue);
+            var animationGroupExportTime = watch.ElapsedMilliseconds / 1000.0 -nodesExportTime;
+            RaiseMessage(string.Format("Animation groups exported in {0:0.00}s", animationGroupExportTime), Color.Blue);
 #endif
 
             if (isBabylonExported)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -211,9 +211,10 @@ namespace Max2Babylon
             string fileExportString = exportNode != null? $"{exportNode.NodeName} | {exportParameters.outputPath}": exportParameters.outputPath;
             RaiseMessage($"Exportation started: {fileExportString}", Color.Blue);
 
-
+#if DEBUG
             var t1 = watch.ElapsedMilliseconds / 1000.0;
             RaiseMessage(string.Format("Containers merged in {0:0.00}s", t1 ), Color.Blue);
+#endif
 
             this.scaleFactor = Tools.GetScaleFactorToMeters();
 
@@ -566,9 +567,11 @@ namespace Max2Babylon
                     ExportSkin(skin, babylonScene);
                 }
             }
-            
+
+#if DEBUG
             var t2 = watch.ElapsedMilliseconds / 1000.0 -t1;
             RaiseMessage(string.Format("Noded exported in {0:0.00}s", t2), Color.Blue);
+#endif
 
             // ----------------------------
             // ----- Animation groups -----
@@ -576,9 +579,10 @@ namespace Max2Babylon
             RaiseMessage("Export animation groups");
             // add animation groups to the scene
             babylonScene.animationGroups = ExportAnimationGroups(babylonScene);
-
+#if DEBUG
             var t3 = watch.ElapsedMilliseconds / 1000.0 -t2;
             RaiseMessage(string.Format("Animation groups exported in {0:0.00}s", t3), Color.Blue);
+#endif
 
             if (isBabylonExported)
             {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -136,18 +136,6 @@ namespace Max2Babylon
                 return;
 
             }
-            
-            if (node.IsInAnimationGroups(animationGroupList))
-            {
-                string message = $"{node.Name} can't be flatten, because is part of an AnimationGroup";
-                RaiseMessage(message, 0);
-                for (int i = 0; i < node.NumChildren; i++)
-                {
-                    IINode n = node.GetChildNode(i);
-                    IsMeshFlattenable(n,animationGroupList,ref flattenableNodes);
-                }
-                return;
-            }
 
             if (node.IsNodeTreeAnimated())
             {
@@ -157,6 +145,18 @@ namespace Max2Babylon
                 {
                     IINode n = node.GetChildNode(i);
                     IsMeshFlattenable(n,animationGroupList,ref flattenableNodes);
+                }
+                return;
+            }
+
+            if (node.IsInAnimationGroups(animationGroupList))
+            {
+                string message = $"{node.Name} can't be flatten, because is part of an AnimationGroup";
+                RaiseMessage(message, 0);
+                for (int i = 0; i < node.NumChildren; i++)
+                {
+                    IINode n = node.GetChildNode(i);
+                    IsMeshFlattenable(n, animationGroupList, ref flattenableNodes);
                 }
                 return;
             }
@@ -205,6 +205,8 @@ namespace Max2Babylon
                 if(maxExporterParameters.flattenScene) FlattenHierarchy(exportNode);
                 if(maxExporterParameters.mergeInheritedContainers)ExportClosedContainers();
             }
+
+            Tools.InitializeGuidNodesMap();
 
             string fileExportString = exportNode != null? $"{exportNode.NodeName} | {exportParameters.outputPath}": exportParameters.outputPath;
             RaiseMessage($"Exportation started: {fileExportString}", Color.Blue);
@@ -399,7 +401,7 @@ namespace Max2Babylon
             var progression = 10.0f;
             ReportProgressChanged((int)progression);
             referencedMaterials.Clear();
-            Tools.guids.Clear();
+
             // Reseting is optionnal. It makes each morph target manager export starts from id = 0.
             BabylonMorphTargetManager.Reset();
             foreach (var maxRootNode in maxRootNodes)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -192,8 +192,12 @@ namespace Max2Babylon
 
         public void Export(ExportParameters exportParameters)
         {
+            var watch = new Stopwatch();
+            watch.Start();
+
             this.exportParameters = exportParameters;
             IINode exportNode = null;
+            
             if (exportParameters is MaxExportParameters)
             {
                 MaxExportParameters maxExporterParameters = (exportParameters as MaxExportParameters);
@@ -202,7 +206,12 @@ namespace Max2Babylon
                 if(maxExporterParameters.mergeInheritedContainers)ExportClosedContainers();
             }
 
-           
+            string fileExportString = exportNode != null? $"{exportNode.NodeName} | {exportParameters.outputPath}": exportParameters.outputPath;
+            RaiseMessage($"Exportation started: {fileExportString}", Color.Blue);
+
+
+            var t1 = watch.ElapsedMilliseconds / 1000.0;
+            RaiseMessage(string.Format("Containers merged in {0:0.00}s", t1 ), Color.Blue);
 
             this.scaleFactor = Tools.GetScaleFactorToMeters();
 
@@ -246,10 +255,7 @@ namespace Max2Babylon
 
             IsCancelled = false;
 
-            string fileExportString = exportNode != null
-                ? $"{exportNode.NodeName} | {exportParameters.outputPath}"
-                : exportParameters.outputPath;
-            RaiseMessage($"Exportation started: {fileExportString}", Color.Blue);
+            
             ReportProgressChanged(0);
 
             string tempOutputDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -275,8 +281,7 @@ namespace Max2Babylon
 
             var rawScene = Loader.Core.RootNode;
 
-            var watch = new Stopwatch();
-            watch.Start();
+           
 
             string outputFormat = exportParameters.outputFormat;
             isBabylonExported = outputFormat == "babylon" || outputFormat == "binary babylon";
@@ -559,6 +564,9 @@ namespace Max2Babylon
                     ExportSkin(skin, babylonScene);
                 }
             }
+            
+            var t2 = watch.ElapsedMilliseconds / 1000.0 -t1;
+            RaiseMessage(string.Format("Noded exported in {0:0.00}s", t2), Color.Blue);
 
             // ----------------------------
             // ----- Animation groups -----
@@ -566,6 +574,9 @@ namespace Max2Babylon
             RaiseMessage("Export animation groups");
             // add animation groups to the scene
             babylonScene.animationGroups = ExportAnimationGroups(babylonScene);
+
+            var t3 = watch.ElapsedMilliseconds / 1000.0 -t2;
+            RaiseMessage(string.Format("Animation groups exported in {0:0.00}s", t3), Color.Blue);
 
             if (isBabylonExported)
             {
@@ -627,7 +638,6 @@ namespace Max2Babylon
                     }
                 }
             }
-
 
             // Output
             babylonScene.Prepare(false, false);

--- a/3ds Max/Max2Babylon/Forms/AnimationForm.cs
+++ b/3ds Max/Max2Babylon/Forms/AnimationForm.cs
@@ -21,7 +21,7 @@ namespace Max2Babylon
         public AnimationForm(BabylonAnimationActionItem babylonAnimationAction)
         {
             InitializeComponent();
-
+            Tools.InitializeGuidNodesMap();
             this.babylonAnimationAction = babylonAnimationAction;
         }
 

--- a/3ds Max/Max2Babylon/GlobalUtility.cs
+++ b/3ds Max/Max2Babylon/GlobalUtility.cs
@@ -63,7 +63,7 @@ namespace Max2Babylon
                 if (contaner != null)
                 {
                     // a generic operation on a container is done (open/inherit)
-                    Tools.guids = new Dictionary<Guid, IAnimatable>();
+                    contaner.ResolveContainer();
                 }
             }
             catch
@@ -81,10 +81,9 @@ namespace Max2Babylon
                 n.GetGuid(); // force to assigne a new guid if not exist yet for this node
 
                 IIContainerObject contaner = Loader.Global.ContainerManagerInterface.IsContainerNode(n);
-                if (contaner!=null)
+                if (contaner != null)
                 {
                     // a generic operation on a container is done (open/inherit)
-                    Tools.guids = new Dictionary<Guid, IAnimatable>();
                     contaner.ResolveContainer();
                 }
             }

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -803,6 +803,7 @@ namespace Max2Babylon
 
         public static void ResolveContainer(this IIContainerObject container)
         {
+            guids = new Dictionary<Guid, IAnimatable>();
             int id = 2;
             while (container.GetConflictingContainer()!=null) //container with same guid  && same name exist)
             {

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -3,6 +3,7 @@ using Max2Babylon.Extensions;
 using SharpDX;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -877,21 +878,24 @@ namespace Max2Babylon
             return handles;
         }
 
+        public static IDictionary<Guid, IAnimatable> guids = new Dictionary<Guid, IAnimatable>();
+
         public static IINode GetINodeByGuid(Guid guid)
+        {
+            if (guid.Equals(Guid.Empty)) return null;
+            IAnimatable result = null;
+            guids.TryGetValue(guid,out result);
+            return result as IINode;
+        }
+
+        public static void InitializeGuidNodesMap()
         {
             IINode root = Loader.Core.RootNode;
             foreach (IINode iNode in root.NodeTree())
             {
-                if (iNode.GetGuid().Equals(guid))
-                {
-                    return iNode;
-                }
+                iNode.GetGuid();
             }
-
-            return null;
         }
-
-        public static IDictionary<Guid, IAnimatable> guids = new Dictionary<Guid, IAnimatable>();
 
         public static Guid GetGuid<T>(this T animatable) where T: IAnimatable
         {
@@ -1087,6 +1091,37 @@ namespace Max2Babylon
             }
 
             node.SetStringProperty(propertyName, builder.ToString());
+        }
+
+
+        public static void SetDictionaryProperty<T1, T2>(this IINode node, string propertyName, IDictionary<T1,T2> stringDictionary)
+        {
+            //myProp = "key:value";"key:value"
+            StringBuilder builder = new StringBuilder();
+            bool first = true;           
+
+            foreach (KeyValuePair<T1, T2> keyValue in stringDictionary)
+            {
+                if (first) first = false;
+                else builder.Append(';');
+
+                builder.AppendFormat("{0}:{1}",keyValue.Key.ToString(),keyValue.Value.ToString());
+            }
+
+            node.SetStringProperty(propertyName, builder.ToString());
+        }
+
+        public static Dictionary<string, string> GetDictionaryProperty(this IINode node, string propertyName)
+        {
+            Dictionary<string, string> result = new Dictionary<string, string>();
+            string stringDictionaryProp = node.GetStringProperty(propertyName, string.Empty);
+            string[] stringkeyValuePairs = stringDictionaryProp.Split(';');
+            foreach (string pair in stringkeyValuePairs)
+            {
+                string[] p = pair.Split(':');
+                result.Add(p[0], p[1]);
+            }
+            return result;
         }
 
         /// <summary>

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.cs
@@ -33,6 +33,8 @@ namespace Babylon2GLTF
             this.logger = logger;
 
             logger.RaiseMessage("GLTFExporter | Exportation started", Color.Blue);
+            var watch = new Stopwatch();
+            watch.Start();
             
             // Force output file extension to be gltf
             outputFileName = Path.ChangeExtension(outputFileName, "gltf");
@@ -83,6 +85,8 @@ namespace Babylon2GLTF
                 logger.ReportProgressChanged((int)progression);
                 logger.CheckCancelled();
             }
+            var t1 = watch.ElapsedMilliseconds / 1000.0;
+            logger.RaiseMessage(string.Format("GLTFMeshes exported in {0:0.00}s", t1), Color.Blue);
  
 
             // Root nodes
@@ -101,6 +105,9 @@ namespace Babylon2GLTF
                 logger.CheckCancelled();
             });
 
+            var t2 = watch.ElapsedMilliseconds / 1000.0 -t1;
+            logger.RaiseMessage(string.Format("GLTFNodes exported in {0:0.00}s", t2), Color.Blue);
+
             // Materials
             logger.RaiseMessage("GLTFExporter | Exporting materials");
             foreach (var babylonMaterial in babylonMaterialsToExport)
@@ -110,9 +117,15 @@ namespace Babylon2GLTF
             };
             logger.RaiseMessage(string.Format("GLTFExporter | Nb materials exported: {0}", gltf.MaterialsList.Count), Color.Gray, 1);
 
+            var t3 = watch.ElapsedMilliseconds / 1000.0 -t2;
+            logger.RaiseMessage(string.Format("GLTFMaterials exported in {0:0.00}s", t3), Color.Blue);
+
             // Animations
             logger.RaiseMessage("GLTFExporter | Exporting Animations");
             ExportAnimationGroups(gltf, babylonScene);
+
+            var t4 = watch.ElapsedMilliseconds / 1000.0 -t3;
+            logger.RaiseMessage(string.Format("GLTFAnimations exported in {0:0.00}s", t4), Color.Blue);
 
             // Prepare buffers
             gltf.BuffersList.ForEach(buffer =>

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.cs
@@ -88,8 +88,8 @@ namespace Babylon2GLTF
                 logger.CheckCancelled();
             }
 #if DEBUG
-            var t1 = watch.ElapsedMilliseconds / 1000.0;
-            logger.RaiseMessage(string.Format("GLTFMeshes exported in {0:0.00}s", t1), Color.Blue);
+            var meshesExportTime = watch.ElapsedMilliseconds / 1000.0;
+            logger.RaiseMessage(string.Format("GLTFMeshes exported in {0:0.00}s", meshesExportTime), Color.Blue);
 #endif
  
 
@@ -109,8 +109,8 @@ namespace Babylon2GLTF
                 logger.CheckCancelled();
             });
 #if DEBUG
-            var t2 = watch.ElapsedMilliseconds / 1000.0 -t1;
-            logger.RaiseMessage(string.Format("GLTFNodes exported in {0:0.00}s", t2), Color.Blue);
+            var nodesExportTime = watch.ElapsedMilliseconds / 1000.0 -meshesExportTime;
+            logger.RaiseMessage(string.Format("GLTFNodes exported in {0:0.00}s", nodesExportTime), Color.Blue);
 #endif
             // Materials
             logger.RaiseMessage("GLTFExporter | Exporting materials");
@@ -121,15 +121,15 @@ namespace Babylon2GLTF
             };
             logger.RaiseMessage(string.Format("GLTFExporter | Nb materials exported: {0}", gltf.MaterialsList.Count), Color.Gray, 1);
 #if DEBUG
-            var t3 = watch.ElapsedMilliseconds / 1000.0 -t2;
-            logger.RaiseMessage(string.Format("GLTFMaterials exported in {0:0.00}s", t3), Color.Blue);
+            var materialsExportTime = watch.ElapsedMilliseconds / 1000.0 -nodesExportTime;
+            logger.RaiseMessage(string.Format("GLTFMaterials exported in {0:0.00}s", materialsExportTime), Color.Blue);
 #endif
             // Animations
             logger.RaiseMessage("GLTFExporter | Exporting Animations");
             ExportAnimationGroups(gltf, babylonScene);
 #if DEBUG
-            var t4 = watch.ElapsedMilliseconds / 1000.0 -t3;
-            logger.RaiseMessage(string.Format("GLTFAnimations exported in {0:0.00}s", t4), Color.Blue);
+            var animationGroupsExportTime = watch.ElapsedMilliseconds / 1000.0 -materialsExportTime;
+            logger.RaiseMessage(string.Format("GLTFAnimations exported in {0:0.00}s", animationGroupsExportTime), Color.Blue);
 #endif
             // Prepare buffers
             gltf.BuffersList.ForEach(buffer =>

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.cs
@@ -33,9 +33,11 @@ namespace Babylon2GLTF
             this.logger = logger;
 
             logger.RaiseMessage("GLTFExporter | Exportation started", Color.Blue);
+#if DEBUG
             var watch = new Stopwatch();
             watch.Start();
-            
+#endif
+
             // Force output file extension to be gltf
             outputFileName = Path.ChangeExtension(outputFileName, "gltf");
 
@@ -85,8 +87,10 @@ namespace Babylon2GLTF
                 logger.ReportProgressChanged((int)progression);
                 logger.CheckCancelled();
             }
+#if DEBUG
             var t1 = watch.ElapsedMilliseconds / 1000.0;
             logger.RaiseMessage(string.Format("GLTFMeshes exported in {0:0.00}s", t1), Color.Blue);
+#endif
  
 
             // Root nodes
@@ -104,10 +108,10 @@ namespace Babylon2GLTF
                 logger.ReportProgressChanged((int)progression);
                 logger.CheckCancelled();
             });
-
+#if DEBUG
             var t2 = watch.ElapsedMilliseconds / 1000.0 -t1;
             logger.RaiseMessage(string.Format("GLTFNodes exported in {0:0.00}s", t2), Color.Blue);
-
+#endif
             // Materials
             logger.RaiseMessage("GLTFExporter | Exporting materials");
             foreach (var babylonMaterial in babylonMaterialsToExport)
@@ -116,17 +120,17 @@ namespace Babylon2GLTF
                 logger.CheckCancelled();
             };
             logger.RaiseMessage(string.Format("GLTFExporter | Nb materials exported: {0}", gltf.MaterialsList.Count), Color.Gray, 1);
-
+#if DEBUG
             var t3 = watch.ElapsedMilliseconds / 1000.0 -t2;
             logger.RaiseMessage(string.Format("GLTFMaterials exported in {0:0.00}s", t3), Color.Blue);
-
+#endif
             // Animations
             logger.RaiseMessage("GLTFExporter | Exporting Animations");
             ExportAnimationGroups(gltf, babylonScene);
-
+#if DEBUG
             var t4 = watch.ElapsedMilliseconds / 1000.0 -t3;
             logger.RaiseMessage(string.Format("GLTFAnimations exported in {0:0.00}s", t4), Color.Blue);
-
+#endif
             // Prepare buffers
             gltf.BuffersList.ForEach(buffer =>
             {


### PR DESCRIPTION
I made a pass of optimization.
Animation group were looking for the node by GUID traversing all the scene over and over
Now this happens only if the node is not found in the GUID dictionary

This is the result before and after on two big files.
Consider that there are almost 500 animation groups for each file
There is still a lot of work to do especially exporting nodes, but this is just a first step
![image](https://user-images.githubusercontent.com/4441151/64948893-55487d80-d878-11e9-9bc5-a82440c85d13.png)
