### PR TITLE
removed guid suffix for gltf bones

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -309,7 +309,7 @@ namespace Max2Babylon
                 // create the bone
                 BabylonBone bone = new BabylonBone()
                 {
-                    id = node.MaxNode.GetGuid().ToString() + "-bone",// the suffix "-bone" is added in babylon export format to assure the uniqueness of IDs
+                    id = (isBabylonExported)?node.MaxNode.GetGuid().ToString() + "-bone":node.MaxNode.GetGuid().ToString(),// the suffix "-bone" is added in babylon export format to assure the uniqueness of IDs
                     name = node.Name,
                     index = nodeIndices.IndexOf(node.NodeID),
                     parentBoneIndex = parentIndex,


### PR DESCRIPTION
this suffix was only for babylon exporter until last month
It was causing node duplication on the exporter gltf
[skin.zip](https://github.com/BabylonJS/Exporters/files/3630129/skin.zip)
I used this file to test it