### PR TITLE
animation group panel must be closed when export begin

### DIFF
--- a/3ds Max/Max2Babylon/BabylonAnimationActionItem.cs
+++ b/3ds Max/Max2Babylon/BabylonAnimationActionItem.cs
@@ -7,7 +7,7 @@ namespace Max2Babylon
 	public class BabylonAnimationActionItem : ActionItem
 	{
         NativeWindow parentWindow;
-        private AnimationForm form;
+        public static AnimationForm form;
 
 		public override bool ExecuteAction()
 		{

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -281,6 +281,7 @@ namespace Max2Babylon
 
         private async Task<bool> DoExport(ExportItem exportItem, bool multiExport = false, bool clearLogs = true)
         {
+            new BabylonAnimationActionItem().Close(); 
             SaveOptions();
 
             //store layer visibility status and force visibility on


### PR DESCRIPTION
The Hold/Fetch logic combined with container export, modify the animation group panel and his serialization under the hood.
In this way, the panel is broken when the export is finished.
To easily fix this I just force the panel to close when export start