### PR TITLE
Load/Save AnimationGroup based on selection, support for nested container

### DIFF
--- a/3ds Max/Max2Babylon/BabylonLoadAnimationFromContainers.cs
+++ b/3ds Max/Max2Babylon/BabylonLoadAnimationFromContainers.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Forms;
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using Autodesk.Max;
 using ActionItem = Autodesk.Max.Plugins.ActionItem;
 
 namespace Max2Babylon
@@ -8,7 +10,39 @@ namespace Max2Babylon
 
         public override bool ExecuteAction()
         {
-            AnimationGroupList.LoadDataFromContainers();
+            if (Loader.Core.SelNodeCount == 0)
+            {
+                MessageBox.Show("No Container selected");
+                return false;
+            }
+#if MAX2020
+            IINodeTab selection = Loader.Global.INodeTab.Create();
+#else
+            IINodeTab selection = Loader.Global.INodeTabNS.Create();
+#endif
+            Loader.Core.GetSelNodeTab(selection);
+            List<IIContainerObject> selectedContainers = new List<IIContainerObject>();
+
+            for (int i = 0; i < selection.Count; i++)
+            {
+                IIContainerObject containerObject  = Loader.Global.ContainerManagerInterface.IsContainerNode(selection[i]);
+                if (containerObject != null)
+                {
+                    selectedContainers.Add(containerObject);
+                }
+            }
+
+            if (selectedContainers.Count <= 0)
+            {
+                MessageBox.Show("No Container selected");
+                return false;
+            }
+
+            foreach (IIContainerObject containerObject in selectedContainers)
+            {
+                AnimationGroupList.LoadDataFromContainer(containerObject);
+            }
+
             return true;
         }
 
@@ -24,12 +58,12 @@ namespace Max2Babylon
 
         public override string ButtonText
         {
-            get { return "Babylon Load Animation From Containers"; }
+            get { return "Babylon Load Animation From Selected Containers"; }
         }
 
         public override string MenuText
         {
-            get { return "&Babylon Load Animation From Containers..."; }
+            get { return "&Babylon Load Animation From Selected Containers..."; }
         }
 
         public override string DescriptionText

--- a/3ds Max/Max2Babylon/BabylonLoadAnimationFromContainers.cs
+++ b/3ds Max/Max2Babylon/BabylonLoadAnimationFromContainers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using Autodesk.Max;
 using ActionItem = Autodesk.Max.Plugins.ActionItem;
@@ -25,7 +26,12 @@ namespace Max2Babylon
 
             for (int i = 0; i < selection.Count; i++)
             {
-                IIContainerObject containerObject  = Loader.Global.ContainerManagerInterface.IsContainerNode(selection[i]);
+#if MAX2015
+                var selectedNode = selection[(IntPtr)i];
+#else
+                var selectedNode = selection[i];
+#endif
+                IIContainerObject containerObject  = Loader.Global.ContainerManagerInterface.IsContainerNode(selectedNode);
                 if (containerObject != null)
                 {
                     selectedContainers.Add(containerObject);

--- a/3ds Max/Max2Babylon/BabylonSaveAnimationToContainers.cs
+++ b/3ds Max/Max2Babylon/BabylonSaveAnimationToContainers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using Autodesk.Max;
 using ActionItem = Autodesk.Max.Plugins.ActionItem;
@@ -26,7 +27,13 @@ namespace Max2Babylon
 
             for (int i = 0; i < selection.Count; i++)
             {
-                IIContainerObject containerObject  = Loader.Global.ContainerManagerInterface.IsContainerNode(selection[i]);
+#if MAX2015
+                var selectedNode = selection[(IntPtr)i];
+#else
+                var selectedNode = selection[i];
+#endif
+                
+                IIContainerObject containerObject  = Loader.Global.ContainerManagerInterface.IsContainerNode(selectedNode);
                 if (containerObject != null)
                 {
                     selectedContainers.Add(containerObject);

--- a/3ds Max/Max2Babylon/BabylonSaveAnimationToContainers.cs
+++ b/3ds Max/Max2Babylon/BabylonSaveAnimationToContainers.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Forms;
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using Autodesk.Max;
 using ActionItem = Autodesk.Max.Plugins.ActionItem;
 
 namespace Max2Babylon
@@ -8,7 +10,41 @@ namespace Max2Babylon
 
         public override bool ExecuteAction()
         {
-            AnimationGroupList.SaveDataToContainers();
+            if (Loader.Core.SelNodeCount == 0)
+            {
+                MessageBox.Show("No Container selected");
+                return false;
+            }
+
+#if MAX2020
+            IINodeTab selection = Loader.Global.INodeTab.Create();
+#else
+            IINodeTab selection = Loader.Global.INodeTabNS.Create();
+#endif
+            Loader.Core.GetSelNodeTab(selection);
+            List<IIContainerObject> selectedContainers = new List<IIContainerObject>();
+
+            for (int i = 0; i < selection.Count; i++)
+            {
+                IIContainerObject containerObject  = Loader.Global.ContainerManagerInterface.IsContainerNode(selection[i]);
+                if (containerObject != null)
+                {
+                    selectedContainers.Add(containerObject);
+                }
+            }
+
+            if (selectedContainers.Count <= 0)
+            {
+                MessageBox.Show("No Container selected");
+                return false;
+            }
+
+            foreach (IIContainerObject containerObject in selectedContainers)
+            {
+                AnimationGroupList.SaveDataToContainer(containerObject);
+            }
+
+            
             return true;
         }
 
@@ -24,12 +60,12 @@ namespace Max2Babylon
 
         public override string ButtonText
         {
-            get { return "Babylon Save Animation To Containers"; }
+            get { return "Babylon Save Animation To Selected Containers"; }
         }
 
         public override string MenuText
         {
-            get { return "&Babylon Save Animation To Containers..."; }
+            get { return "&Babylon Save Animation To Selected Containers..."; }
         }
 
         public override string DescriptionText

--- a/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
+++ b/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
@@ -526,7 +526,7 @@ namespace Max2Babylon
             container.BabylonContainerHelper().GetUserPropBuffer(ref helperPropBuffer);
 
             List<IINode> containerHierarchy = new List<IINode>() { container.ContainerNode };
-            containerHierarchy.AddRange(container.ContainerNode.NodeTree());
+            containerHierarchy.AddRange(container.ContainerNode.ContainerNodeTree(false));
 
             int containerID = 1;
             container.ContainerNode.GetUserPropInt("babylonjs_ContainerID", ref containerID);

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -185,7 +185,7 @@ namespace Max2Babylon
             foreach (IIContainerObject containerObject in sceneContainers)
             {
                 if (!containerObject.IsInherited)continue;
-                bool merge = containerObject.MergeSource;
+                bool makeUnique = containerObject.MakeUnique;
             }
             AnimationGroupList.LoadDataFromAllContainers();
         }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -187,7 +187,7 @@ namespace Max2Babylon
                 if (!containerObject.IsInherited)continue;
                 bool merge = containerObject.MergeSource;
             }
-            AnimationGroupList.LoadDataFromContainers();
+            AnimationGroupList.LoadDataFromAllContainers();
         }
 
         public void Export(ExportParameters exportParameters)

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -798,6 +798,24 @@ namespace Max2Babylon
             return containersList;
         }
 
+        public static IEnumerable<IINode> ContainerNodeTree(this IINode containerNode, bool includeSubContainer)
+        {
+            foreach (IINode x in containerNode.Nodes())
+            {
+                IIContainerObject nestedContainerObject =Loader.Global.ContainerManagerInterface.IsContainerNode(x);
+                if (nestedContainerObject != null && includeSubContainer)
+                {
+                    yield return x;
+                }
+                else
+                {
+                    continue;
+                }
+                foreach (var y in x.ContainerNodeTree(includeSubContainer))
+                    yield return y;
+            }
+        }
+
         private static IIContainerObject GetConflictingContainer(this IIContainerObject container)
         {
             string guidStr = container.ContainerNode.GetStringProperty("babylonjs_GUID",Guid.NewGuid().ToString());
@@ -841,7 +859,15 @@ namespace Max2Babylon
 
         public static IINode BabylonContainerHelper(this IIContainerObject containerObject)
         {
-            IINode babylonHelper = containerObject.ContainerNode.FindChildNode("BabylonAnimationHelper");
+            IINode babylonHelper = null;
+            foreach (IINode directChild in containerObject.ContainerNode.DirectChildren())
+            {
+                if (directChild.Name == "BabylonAnimationHelper")
+                {
+                    babylonHelper = directChild;
+                }
+            }
+
             if (babylonHelper == null)
             {
                 MessageBox.Show($"Container {containerObject.ContainerNode.Name} has no Babylon Animation Helper, " +


### PR DESCRIPTION
As requested from artists the load/save animation group is based on the selected container
This improves the experience of working with containers
Also now nested containers are supported