### PR TITLE
Fix null camera scale in gltf export

### DIFF
--- a/Maya/Exporter/BabylonExporter.Camera.cs
+++ b/Maya/Exporter/BabylonExporter.Camera.cs
@@ -94,6 +94,7 @@ namespace Maya2Babylon
             var rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
             GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling);
             babylonCamera.position = position;
+            babylonCamera.scaling = scaling;
             if (_exportQuaternionsInsteadOfEulers)
             {
                 babylonCamera.rotationQuaternion = rotationQuaternion;


### PR DESCRIPTION
Proposed fix for issue #643 where Maya exporter camera scale is null value Adds scaling assignment to BabylonCamera after TRS is retrieved from Maya