### PR TITLE
Bug fix animgroup, checkbox containers, flatten hierachy

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -274,24 +274,31 @@ namespace Max2Babylon
             {
                 MaxExportParameters maxExporterParameters = (exportParameters as MaxExportParameters);
                 exportNode = maxExporterParameters.exportNode;
-                if (maxExporterParameters.mergeContainersAndXRef)
+
+                if (maxExporterParameters.usePreExportProcess)
                 {
-                    string message = "Merging containers and Xref...";
-                    RaiseMessage(message, 0);
-                    ExportClosedContainers();
-                    Tools.MergeAllXrefRecords();
+                    if (maxExporterParameters.mergeContainersAndXRef)
+                    {
+                        string message = "Merging containers and Xref...";
+                        RaiseMessage(message, 0);
+                        ExportClosedContainers();
+                        Tools.MergeAllXrefRecords();
 #if DEBUG
-                    var containersXrefMergeTime = watch.ElapsedMilliseconds / 1000.0;
-                    RaiseMessage(string.Format("Containers and Xref  merged in {0:0.00}s", containersXrefMergeTime ), Color.Blue);
+                        var containersXrefMergeTime = watch.ElapsedMilliseconds / 1000.0;
+                        RaiseMessage(string.Format("Containers and Xref  merged in {0:0.00}s", containersXrefMergeTime ), Color.Blue);
 #endif
+                    }
+                    BakeAnimationsFrame(exportNode,maxExporterParameters.bakeAnimationType);
                 }
 
-                if(maxExporterParameters.flattenScene) FlattenItem(ref exportNode);
-
+                if (maxExporterParameters.flattenScene)
+                {
+                    FlattenItem(ref exportNode);
 #if DEBUG
-                flattenTime = watch.ElapsedMilliseconds / 1000.0;
-                RaiseMessage(string.Format("Nodes falattened in {0:0.00}s", flattenTime ), Color.Blue);
+                    flattenTime = watch.ElapsedMilliseconds / 1000.0;
+                    RaiseMessage(string.Format("Nodes flattened in {0:0.00}s", flattenTime ), Color.Blue);
 #endif
+                }
             }
 
             Tools.InitializeGuidNodesMap();
@@ -625,7 +632,7 @@ namespace Max2Babylon
             {
                 var atmospheric = Loader.Core.GetAtmospheric(index);
 
-                if (atmospheric.Active(0) && atmospheric.ClassName == "Fog")
+                if (atmospheric!=null && atmospheric.Active(0) && atmospheric.ClassName == "Fog")
                 {
                     var fog = atmospheric as IStdFog;
 

--- a/3ds Max/Max2Babylon/Forms/AnimationGroupControl.cs
+++ b/3ds Max/Max2Babylon/Forms/AnimationGroupControl.cs
@@ -161,6 +161,22 @@ namespace Max2Babylon
             if (nodesChanged)
             {
                 confirmedInfo.NodeGuids = newHandles.ToGuids();
+                if (confirmedInfo.AnimationGroupNodes == null)
+                {
+                    confirmedInfo.AnimationGroupNodes = new List<AnimationGroupNode>();
+                }
+                
+                foreach (uint handle in newHandles)
+                {
+                    IINode node = Loader.Core.GetINodeByHandle(handle);
+                    if (node != null)
+                    {
+                        string name = node.Name;
+                        string parentName = node.ParentNode.Name;
+                        AnimationGroupNode nodeData = new AnimationGroupNode(node.GetGuid(), name, parentName);
+                        confirmedInfo.AnimationGroupNodes.Add(nodeData);
+                    }
+                }
             }
 
             ResetChangedTextBoxColors();

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -693,12 +693,15 @@ namespace Max2Babylon
 
         public static IINode FlattenHierarchy(this IINode node)
         {
+            string activeLayer =$"(LayerManager.getLayerFromName (maxOps.getNodeByHandle {node.Handle}).layer.name).current = true";
+            ScriptsUtilities.ExecuteMaxScriptCommand(activeLayer);
             node.SetUserPropBool("babylonjs_flattened", true);
             node.NodeTree().ToList().ForEach(x => x.SetUserPropBool("babylonjs_flattened",true));
             IClass_ID cid = Loader.Global.Class_ID.Create((uint)BuiltInClassIDA.SPHERE_CLASS_ID, 0);
             object obj = Loader.Core.CreateInstance(SClass_ID.Geomobject, cid as IClass_ID);
             IINode result = Loader.Core.CreateObjectNode((IObject)obj);
             result.Name = node.Name;
+            result.SetTMController(node.TMController);
             string scale = $"scale (maxOps.getNodeByHandle {result.Handle}) [0.1,0.1,0.1]";
             ScriptsUtilities.ExecuteMaxScriptCommand(scale);
             result.ResetTransform(Loader.Core.Time,false);


### PR DESCRIPTION
this is just a polish bug fix pull request
clean button was removing the animation group if the button was clicked just after the creation of the animation group 
the flatten hierarchy feature has been reduced to the multi export item, too many problems when launching from the generic exporter
the containers were merged when the use preexport process was false and the container checkbox was true