### PR TITLE
move bake/no-bake node animation to babylon properties panel

### DIFF
--- a/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
+++ b/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
@@ -145,9 +145,6 @@
     <Compile Include="..\BabylonStoreAnimations.cs">
       <Link>BabylonStoreAnimations.cs</Link>
     </Compile>
-    <Compile Include="..\BabylonToggleBakeAnimation.cs">
-      <Link>BabylonToggleBakeAnimation.cs</Link>
-    </Compile>
     <Compile Include="..\Descriptor.cs">
       <Link>Descriptor.cs</Link>
     </Compile>

--- a/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
+++ b/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
@@ -146,9 +146,6 @@
     <Compile Include="..\BabylonStoreAnimations.cs">
       <Link>BabylonStoreAnimations.cs</Link>
     </Compile>
-    <Compile Include="..\BabylonToggleBakeAnimation.cs">
-      <Link>BabylonToggleBakeAnimation.cs</Link>
-    </Compile>
     <Compile Include="..\Descriptor.cs">
       <Link>Descriptor.cs</Link>
     </Compile>

--- a/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
+++ b/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
@@ -145,9 +145,6 @@
     <Compile Include="..\BabylonStoreAnimations.cs">
       <Link>BabylonStoreAnimations.cs</Link>
     </Compile>
-    <Compile Include="..\BabylonToggleBakeAnimation.cs">
-      <Link>BabylonToggleBakeAnimation.cs</Link>
-    </Compile>
     <Compile Include="..\Descriptor.cs">
       <Link>Descriptor.cs</Link>
     </Compile>

--- a/3ds Max/Max2Babylon/2019/Max2Babylon2019.csproj
+++ b/3ds Max/Max2Babylon/2019/Max2Babylon2019.csproj
@@ -149,9 +149,6 @@
     <Compile Include="..\BabylonStoreAnimations.cs">
       <Link>BabylonStoreAnimations.cs</Link>
     </Compile>
-    <Compile Include="..\BabylonToggleBakeAnimation.cs">
-      <Link>BabylonToggleBakeAnimation.cs</Link>
-    </Compile>
     <Compile Include="..\Descriptor.cs">
       <Link>Descriptor.cs</Link>
     </Compile>

--- a/3ds Max/Max2Babylon/2020/Max2Babylon2020.csproj
+++ b/3ds Max/Max2Babylon/2020/Max2Babylon2020.csproj
@@ -149,9 +149,6 @@
     <Compile Include="..\BabylonStoreAnimations.cs">
       <Link>BabylonStoreAnimations.cs</Link>
     </Compile>
-    <Compile Include="..\BabylonToggleBakeAnimation.cs">
-      <Link>BabylonToggleBakeAnimation.cs</Link>
-    </Compile>
     <Compile Include="..\Descriptor.cs">
       <Link>Descriptor.cs</Link>
     </Compile>

--- a/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
+++ b/3ds Max/Max2Babylon/Exporter/AnimationGroup.cs
@@ -613,7 +613,14 @@ namespace Max2Babylon
 
                 if (containerID > 1 && !n.Name.EndsWith("_ID_" +containerID))
                 {
+                    string originalName = n.Name;
                     n.Name = $"{n.Name}_ID_{containerID}";
+                    IINode source = Loader.Core.GetINodeByName(originalName);
+                    IMtl mat = source.Mtl;
+                    if (mat != null)
+                    {
+                        n.Mtl = mat;
+                    }
                 }
             }
 

--- a/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.Designer.cs
+++ b/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.Designer.cs
@@ -33,6 +33,8 @@
             this.butCancel = new System.Windows.Forms.Button();
             this.butOK = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.tagLabel = new System.Windows.Forms.Label();
+            this.tagInput = new System.Windows.Forms.TextBox();
             this.nupAlphaIndex = new System.Windows.Forms.NumericUpDown();
             this.label3 = new System.Windows.Forms.Label();
             this.chkNoExport = new System.Windows.Forms.CheckBox();
@@ -84,8 +86,7 @@
             this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.chkAutoPlay = new System.Windows.Forms.CheckBox();
             this.ofdOpenSound = new System.Windows.Forms.OpenFileDialog();
-            this.tagInput = new System.Windows.Forms.TextBox();
-            this.tagLabel = new System.Windows.Forms.Label();
+            this.chkBakeAnimationNode = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nupAlphaIndex)).BeginInit();
@@ -177,6 +178,22 @@
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Misc.";
             // 
+            // tagLabel
+            // 
+            this.tagLabel.AutoSize = true;
+            this.tagLabel.Location = new System.Drawing.Point(18, 124);
+            this.tagLabel.Name = "tagLabel";
+            this.tagLabel.Size = new System.Drawing.Size(29, 13);
+            this.tagLabel.TabIndex = 18;
+            this.tagLabel.Text = "Tag:";
+            // 
+            // tagInput
+            // 
+            this.tagInput.Location = new System.Drawing.Point(89, 121);
+            this.tagInput.Name = "tagInput";
+            this.tagInput.Size = new System.Drawing.Size(100, 20);
+            this.tagInput.TabIndex = 19;
+            // 
             // nupAlphaIndex
             // 
             this.nupAlphaIndex.Location = new System.Drawing.Point(89, 95);
@@ -260,6 +277,7 @@
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.chkBakeAnimationNode);
             this.groupBox3.Controls.Add(this.grpAutoAnimate);
             this.groupBox3.Controls.Add(this.chkAutoAnimate);
             this.groupBox3.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
@@ -831,21 +849,16 @@
             // 
             this.ofdOpenSound.Filter = "Sound files|*.wav;*.mp3";
             // 
-            // tagInput
+            // chkBakeAnimationNode
             // 
-            this.tagInput.Location = new System.Drawing.Point(89, 121);
-            this.tagInput.Name = "tagInput";
-            this.tagInput.Size = new System.Drawing.Size(100, 20);
-            this.tagInput.TabIndex = 19;
-            // 
-            // tagLabel
-            // 
-            this.tagLabel.AutoSize = true;
-            this.tagLabel.Location = new System.Drawing.Point(18, 124);
-            this.tagLabel.Name = "tagLabel";
-            this.tagLabel.Size = new System.Drawing.Size(29, 13);
-            this.tagLabel.TabIndex = 18;
-            this.tagLabel.Text = "Tag:";
+            this.chkBakeAnimationNode.AutoSize = true;
+            this.chkBakeAnimationNode.Location = new System.Drawing.Point(121, 28);
+            this.chkBakeAnimationNode.Name = "chkBakeAnimationNode";
+            this.chkBakeAnimationNode.Size = new System.Drawing.Size(129, 17);
+            this.chkBakeAnimationNode.TabIndex = 24;
+            this.chkBakeAnimationNode.Text = "Bake Node Animation";
+            this.chkBakeAnimationNode.ThreeState = true;
+            this.chkBakeAnimationNode.UseVisualStyleBackColor = true;
             // 
             // ObjectPropertiesForm
             // 
@@ -960,5 +973,6 @@
         private System.Windows.Forms.Button cmdFileBrowse;
         private System.Windows.Forms.Label tagLabel;
         private System.Windows.Forms.TextBox tagInput;
+        private System.Windows.Forms.CheckBox chkBakeAnimationNode;
     }
 }

--- a/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.cs
@@ -24,6 +24,7 @@ namespace Max2Babylon
             Tools.UpdateCheckBox(chkShowSubMeshesBoundingBox, objects, "babylonjs_showsubmeshesboundingbox");
 
             Tools.UpdateCheckBox(chkAutoAnimate, objects, "babylonjs_autoanimate");
+            Tools.UpdateCheckBox(chkBakeAnimationNode,objects,"babylonjs_BakeAnimation");
             Tools.UpdateCheckBox(chkLoop, objects, "babylonjs_autoanimateloop");
             Tools.UpdateNumericUpDown(nupFrom, objects, "babylonjs_autoanimate_from");
             Tools.UpdateNumericUpDown(nupTo, objects, "babylonjs_autoanimate_to");
@@ -79,6 +80,7 @@ namespace Max2Babylon
             Tools.PrepareCheckBox(chkShowSubMeshesBoundingBox, objects, "babylonjs_showsubmeshesboundingbox");
 
             Tools.PrepareCheckBox(chkAutoAnimate, objects, "babylonjs_autoanimate", 1);
+            Tools.PrepareCheckBox(chkBakeAnimationNode,objects,"babylonjs_BakeAnimation");
             Tools.PrepareCheckBox(chkLoop, objects, "babylonjs_autoanimateloop", 1);
             Tools.PrepareNumericUpDown(nupFrom, objects, "babylonjs_autoanimate_from");
             Tools.PrepareNumericUpDown(nupTo, objects, "babylonjs_autoanimate_to", 100.0f);

--- a/3ds Max/Max2Babylon/GlobalUtility.cs
+++ b/3ds Max/Max2Babylon/GlobalUtility.cs
@@ -115,11 +115,11 @@ namespace Max2Babylon
                     n.GetGuid(); // force to assigne a new guid if not exist yet for this node
                 }
 
-                IIContainerObject contaner = Loader.Global.ContainerManagerInterface.IsContainerNode(n);
-                if (contaner != null)
+                IIContainerObject container = Loader.Global.ContainerManagerInterface.IsContainerNode(n);
+                if (container != null)
                 {
                     // a generic operation on a container is done (open/inherit)
-                    contaner.ResolveContainer();
+                    container.ResolveContainer();
                 }
             }
             catch
@@ -192,7 +192,6 @@ namespace Max2Babylon
                 actionTable.AppendOperation(new BabylonSaveAnimations());
                 actionTable.AppendOperation(new BabylonLoadAnimations());
                 actionTable.AppendOperation(new BabylonSkipFlattenToggle());
-                actionTable.AppendOperation(new BabylonToggleBakeAnimation());
 
                 actionCallback = new BabylonActionCallback();
 
@@ -340,13 +339,8 @@ namespace Max2Babylon
             menu.AddItem(menuItemBabylon, -1);
 
             menuItemBabylon = Loader.Global.IMenuItem;
-            menuItemBabylon.Title = "Babylon Toggle Bake Animation Status";
-            menuItemBabylon.ActionItem = actionTable[6];
-            menu.AddItem(menuItemBabylon, -1);
-
-            menuItemBabylon = Loader.Global.IMenuItem;
             menuItemBabylon.Title = "Babylon Actions Builder";
-            menuItemBabylon.ActionItem = actionTable[7];
+            menuItemBabylon.ActionItem = actionTable[6];
             menu.AddItem(menuItemBabylon, -1);
 
             menuItem = Loader.Global.IMenuItem;


### PR DESCRIPTION
two minimal improvement

- when a container is imported multiple times, the exporter merges those inside the scene and export.
There were duplicated material in scene and GLTF, now merging the container this duplication is removed

- Bake Node  Animation Enable/Disable logic has been moved to Babylon properties per object panel