### PR TITLE
fix issue on container helper creation with missing animation

### DIFF
--- a/3ds Max/Max2Babylon/BabylonStoreAnimations.cs
+++ b/3ds Max/Max2Babylon/BabylonStoreAnimations.cs
@@ -11,6 +11,7 @@ namespace Max2Babylon
 
         public override bool ExecuteAction()
         {
+            Tools.InitializeGuidNodesMap();
             var selectedContainers = Tools.GetContainerInSelection();
 
             if (selectedContainers.Count <= 0)

--- a/3ds Max/Max2Babylon/GlobalUtility.cs
+++ b/3ds Max/Max2Babylon/GlobalUtility.cs
@@ -120,7 +120,6 @@ namespace Max2Babylon
                 {
                     // a generic operation on a container is done (open/inherit)
                     container.ResolveContainer();
-                    Tools.InitializeGuidNodesMap();
                 }
             }
             catch

--- a/3ds Max/Max2Babylon/GlobalUtility.cs
+++ b/3ds Max/Max2Babylon/GlobalUtility.cs
@@ -120,6 +120,7 @@ namespace Max2Babylon
                 {
                     // a generic operation on a container is done (open/inherit)
                     container.ResolveContainer();
+                    Tools.InitializeGuidNodesMap();
                 }
             }
             catch


### PR DESCRIPTION
in case a user load a scene with a closed container
and store the animation group of the container without opening the Babylon animation group, storing the animation group in the helper was failing because Guids dictionary was not initialized
