### PR TITLE
Explicitly fail when invalid scaling value is provided.

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -588,7 +588,7 @@ namespace Max2Babylon
 
             if (exportParameters.scaleFactor != 1.0f)
             {
-                RaiseMessage("A root node is added for scaling", 1);
+                RaiseMessage(String.Format("A root node is added to globally scale the scene by {0}", exportParameters.scaleFactor), 1);
 
                 // Create root node for scaling
                 BabylonMesh rootNode = new BabylonMesh { name = "root", id = Guid.NewGuid().ToString() };

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -349,12 +349,31 @@ namespace Max2Babylon
             {
                 string modelAbsolutePath = multiExport ? exportItem.ExportFilePathAbsolute : txtModelName.Text;
                 string textureExportPath = multiExport ? exportItem.ExportTexturesesFolderPath : txtTextureName.Text;
+
+                var scaleFactorParsed = 1.0f;
+                var textureQualityParsed = 100L;
+                try
+                {
+                    scaleFactorParsed = float.Parse(txtScaleFactor.Text);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidDataException(String.Format("Invalid Scale Factor value: {0}", txtScaleFactor.Text));
+                }
+                try
+                {
+                    textureQualityParsed = long.Parse(txtQuality.Text);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidDataException(String.Format("Invalid Texture Quality value: {0}", txtScaleFactor.Text));
+                }
                 MaxExportParameters exportParameters = new MaxExportParameters
                 {
                     outputPath = modelAbsolutePath,
                     textureFolder = textureExportPath,
                     outputFormat = comboOutputFormat.SelectedItem.ToString(),
-                    scaleFactor = float.Parse(txtScaleFactor.Text),
+                    scaleFactor = scaleFactorParsed,
                     writeTextures = chkWriteTextures.Checked,
                     overwriteTextures = chkOverwriteTextures.Checked,
                     exportHiddenObjects = chkHidden.Checked,
@@ -364,7 +383,7 @@ namespace Max2Babylon
                     exportTangents = chkExportTangents.Checked,
                     exportMorphTangents = chkExportMorphTangents.Checked,
                     exportMorphNormals = chkExportMorphNormals.Checked,
-                    txtQuality = long.Parse(txtQuality.Text),
+                    txtQuality = textureQualityParsed,
                     mergeAOwithMR = chkMergeAOwithMR.Checked,
                     bakeAnimationType = (BakeAnimationType)cmbBakeAnimationOptions.SelectedIndex,
                     dracoCompression = chkDracoCompression.Checked,

--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -321,7 +321,7 @@ namespace Maya2Babylon
             var sceneScaleFactor = exportParameters.scaleFactor;
             if (exportParameters.scaleFactor != 1.0f)
             {
-                RaiseMessage("A root node is added for scaling", 1);
+                RaiseMessage(String.Format("A root node is added to globally scale the scene by {0}", sceneScaleFactor), 1);
 
                 // Create root node for scaling
                 BabylonMesh rootNode = new BabylonMesh { name = "root", id = Tools.GenerateUUID() };

--- a/Maya/Forms/ExporterForm.cs
+++ b/Maya/Forms/ExporterForm.cs
@@ -206,6 +206,23 @@ namespace Maya2Babylon.Forms
             {
                 var scaleFactorParsed = 1.0f;
                 var textureQualityParsed = 100L;
+                try
+                {
+                    scaleFactorParsed = float.Parse(txtScaleFactor.Text);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidDataException(String.Format("Invalid Scale Factor value: {0}", txtScaleFactor.Text));
+                }
+                try
+                {
+                    textureQualityParsed = long.Parse(txtQuality.Text);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidDataException(String.Format("Invalid Texture Quality value: {0}", txtScaleFactor.Text));
+                }
+    
                 var exportParameters = new ExportParameters
                 {
                     outputPath = txtFilename.Text,
@@ -218,9 +235,9 @@ namespace Maya2Babylon.Forms
                     overwriteTextures = chkCopyTextures.Checked,
                     optimizeVertices = chkOptimizeVertices.Checked,
                     exportTangents = chkExportTangents.Checked,
-                    scaleFactor = float.TryParse(txtScaleFactor.Text, out scaleFactorParsed) ? scaleFactorParsed : 1.0f,
+                    scaleFactor = scaleFactorParsed,
                     exportSkins = chkExportSkin.Checked,
-                    txtQuality = long.TryParse(txtQuality.Text, out textureQualityParsed) ? textureQualityParsed : 100,
+                    txtQuality = textureQualityParsed,
                     dracoCompression = chkDracoCompression.Checked,
                     exportMorphNormals = chkExportMorphNormal.Checked,
                     exportMorphTangents = chkExportMorphTangent.Checked,
@@ -241,9 +258,10 @@ namespace Maya2Babylon.Forms
             }
             catch (Exception ex)
             {
-                currentNode = CreateTreeNode(0, "Export cancelled: " + ex.Message + " " + ex.StackTrace, Color.Red);
-
+                currentNode = CreateTreeNode(0, "Export cancelled: " + ex.Message, Color.Red);
+                currentNode = CreateTreeNode(1, ex.ToString(), Color.Red);
                 currentNode.EnsureVisible();
+
                 progressBar.Value = 0;
                 success = false;
             }


### PR DESCRIPTION
This change explicitly fails exporting the scene when an invalid scene scale factor or texture quality value is provided. The root node scaling print was also modified to include the factor value

Intended to help prevent issues like #687 