### PR TITLE
Fix Babylon->GLTF light radius serialization

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Light.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Light.cs
@@ -45,7 +45,7 @@ namespace Babylon2GLTF
                     light.spot = new GLTFLight.Spot
                     {
                         //innerConeAngle = 0, Babylon doesn't support the innerConeAngle
-                        outerConeAngle = babylonLight.angle
+                        outerConeAngle = babylonLight.angle / 2 // divide by 2 as glTF measures light outer angle from the light's center, while Babylon's light angle measures the whole light's cone angle.
                     };
                     break;
                 default:


### PR DESCRIPTION
Addressing #689, change the gltf light serialization logic to convert light cone diametric angle to light radial angle.