### PR TITLE
added missing check on scene change

### DIFF
--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -31,7 +31,7 @@ namespace Max2Babylon
         private  bool filePostOpenCallback = false;
         private GlobalDelegates.Delegate5 m_FilePostOpenDelegate;
 
-        private void RegisterFilePreOpen()
+        private void RegisterFilePostOpen()
         {
             if (!filePostOpenCallback)
             {
@@ -55,7 +55,7 @@ namespace Max2Babylon
         public ExporterForm(BabylonExportActionItem babylonExportAction)
         {
             InitializeComponent();
-            RegisterFilePreOpen();
+            RegisterFilePostOpen();
 
 
             this.Text = $"Babylon.js - Export scene to babylon or glTF format v{BabylonExporter.exporterVersion}";

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -1710,17 +1710,20 @@ namespace Max2Babylon
 
         public static void MaxPath(this RichTextBox box, string path)
         {
-            string dirName = Loader.Core.GetDir((int)MaxDirectory.ProjectFolder);
-            box.ResetText();
-
-            box.Text = path;
-            box.ForeColor = Color.Black;
-
-            if (path.StartsWith(dirName))
+            if (!box.IsDisposed)
             {
-                box.SelectionStart = 0;
-                box.SelectionLength = dirName.Length;
-                box.SelectionColor = Color.Blue;
+                string dirName = Loader.Core.GetDir((int)MaxDirectory.ProjectFolder);
+                box.ResetText();
+
+                box.Text = path;
+                box.ForeColor = Color.Black;
+
+                if (path.StartsWith(dirName))
+                {
+                    box.SelectionStart = 0;
+                    box.SelectionLength = dirName.Length;
+                    box.SelectionColor = Color.Blue;
+                }
             }
         }
 


### PR DESCRIPTION
a missing check was causing an object disposed exception when the user switched scene and had previously closed the exporter form