### PR TITLE
Add debug formating to .babylon export

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -719,7 +719,11 @@ namespace Max2Babylon
                 var sw = new StringWriter(sb, CultureInfo.InvariantCulture);
                 using (var jsonWriter = new JsonTextWriterOptimized(sw))
                 {
+#if DEBUG
+                    jsonWriter.Formatting = Formatting.Indented;
+#else
                     jsonWriter.Formatting = Formatting.None;
+#endif
                     jsonSerializer.Serialize(jsonWriter, babylonScene);
                 }
                 File.WriteAllText(outputFile, sb.ToString());


### PR DESCRIPTION
Add indented formatting if .babylon file is exported using debug exporter build for improved readability

similar to #705 