### PR TITLE
Remove old version system, replace with Custom.Build.Version

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -33,7 +33,7 @@ namespace Max2Babylon
         private bool optimizeAnimations;
         private bool exportNonAnimated;
 
-        public static string exporterVersion = "1.5.0";
+        public static string exporterVersion = "Custom.Build.Version";
         public float scaleFactor = 1.0f;
 
         public const int MaxSceneTicksPerSecond = 4800; //https://knowledge.autodesk.com/search-result/caas/CloudHelp/cloudhelp/2016/ENU/MAXScript-Help/files/GUID-141213A1-B5A8-457B-8838-E602022C8798-htm.html

--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -31,7 +31,7 @@ namespace Maya2Babylon
         /// </summary>
         private static List<string> defaultCameraNames = new List<string>(new string[] { "persp", "top", "front", "side" });
 
-        public static string exporterVersion = "1.4.0";
+        public static string exporterVersion = "Custom.Build.Version";
 
         /// <summary>
         /// Export to file


### PR DESCRIPTION
Since we moved to a CI pipeline, our old versioning system is no longer needed. This change replaces 1.4.0, and 1.5.0 with Custom.Build.Version, which will be replaced with the relevant version come packaging time.

addressing #712 