### PR TITLE
Refactor gltf-pipeline invoking logic

### DIFF
--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -61,24 +61,9 @@ namespace Max2Babylon
             this.Text = $"Babylon.js - Export scene to babylon or glTF format v{BabylonExporter.exporterVersion}";
 
             this.babylonExportAction = babylonExportAction;
-            
+
             // Check if the gltf-pipeline module is installed
-            try
-            {
-                Process gltfPipeline = new Process();
-                gltfPipeline.StartInfo.FileName = "gltf-pipeline.cmd";
-
-                // Hide the cmd window that show the gltf-pipeline result
-                gltfPipeline.StartInfo.UseShellExecute = false;
-                gltfPipeline.StartInfo.CreateNoWindow = true;
-
-                gltfPipeline.Start();
-                gltfPipeline.WaitForExit();
-            }
-            catch
-            {
-                gltfPipelineInstalled = false;
-            }
+            this.gltfPipelineInstalled = GLTFPipelineUtilities.IsGLTFPipelineInstalled();
 
             groupBox1.MouseMove += groupBox1_MouseMove;
         }

--- a/Maya/Forms/ExporterForm.cs
+++ b/Maya/Forms/ExporterForm.cs
@@ -47,22 +47,7 @@ namespace Maya2Babylon.Forms
             this.Text = $"Babylon.js - Export scene to babylon or glTF format v{BabylonExporter.exporterVersion}";
 
             // Check if the gltf-pipeline module is installed
-            try
-            {
-                Process gltfPipeline = new Process();
-                gltfPipeline.StartInfo.FileName = "gltf-pipeline.cmd";
-
-                // Hide the cmd window that show the gltf-pipeline result
-                gltfPipeline.StartInfo.UseShellExecute = false;
-                gltfPipeline.StartInfo.CreateNoWindow = true;
-
-                gltfPipeline.Start();
-                gltfPipeline.WaitForExit();
-            }
-            catch
-            {
-                gltfPipelineInstalled = false;
-            }
+            gltfPipelineInstalled = GLTFPipelineUtilities.IsGLTFPipelineInstalled();
 
             groupBox1.MouseMove += groupBox1_MouseMove;
         }
@@ -78,7 +63,7 @@ namespace Maya2Babylon.Forms
             chkAutoSave.Checked = Loader.GetBoolProperty(chkAutoSaveProperty, false);
             chkOptimizeVertices.Checked = Loader.GetBoolProperty(chkOptimizeVerticesProperty, true);
             chkExportTangents.Checked = Loader.GetBoolProperty(chkExportTangentsProperty, true);
-            //chkDracoCompression.Checked = Loader.GetBoolProperty(chkDracoCompressionProperty, false);
+            chkDracoCompression.Checked = Loader.GetBoolProperty(chkDracoCompressionProperty, false);
             chkExportSkin.Checked = Loader.GetBoolProperty(chkExportSkinProperty, true);
             chkExportMorphNormal.Checked = Loader.GetBoolProperty(chkExportMorphNormalProperty, true);
             chkExportMorphTangent.Checked = Loader.GetBoolProperty(chkExportMorphTangentProperty, false);
@@ -118,7 +103,7 @@ namespace Maya2Babylon.Forms
             Loader.SetBoolProperty(chkAutoSaveProperty, chkAutoSave.Checked);
             Loader.SetBoolProperty(chkOptimizeVerticesProperty, chkOptimizeVertices.Checked);
             Loader.SetBoolProperty(chkExportTangentsProperty, chkExportTangents.Checked);
-            //Loader.SetBoolProperty(chkDracoCompressionProperty, chkDracoCompression.Checked);
+            Loader.SetBoolProperty(chkDracoCompressionProperty, chkDracoCompression.Checked);
             Loader.SetBoolProperty(chkExportSkinProperty, chkExportSkin.Checked);
             Loader.SetBoolProperty(chkExportMorphNormalProperty, chkExportMorphNormal.Checked);
             Loader.SetBoolProperty(chkExportMorphTangentProperty, chkExportMorphTangent.Checked);

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.cs
@@ -272,38 +272,7 @@ namespace Babylon2GLTF
             if(exportParameters.dracoCompression)
             {
                 logger.RaiseMessage("GLTFExporter | Draco compression");
-
-                try
-                {
-                    Process gltfPipeline = new Process();
-
-                    // Hide the cmd window that show the gltf-pipeline result
-                    //gltfPipeline.StartInfo.UseShellExecute = false;
-                    //gltfPipeline.StartInfo.CreateNoWindow = true;
-                    gltfPipeline.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-
-                    string arg;
-                    if (generateBinary)
-                    {
-                        string outputGlbFile = Path.ChangeExtension(outputFile, "glb");
-                        arg = $" -i {outputGlbFile} -o {outputGlbFile} -d";
-                    }
-                    else
-                    {
-                        string outputGltfFile = Path.ChangeExtension(outputFile, "gltf");
-                        arg = $" -i {outputGltfFile} -o {outputGltfFile} -d -s";
-                    }
-                    gltfPipeline.StartInfo.FileName = "gltf-pipeline.cmd";
-                    gltfPipeline.StartInfo.Arguments = arg;
-
-                    gltfPipeline.Start();
-                    gltfPipeline.WaitForExit();
-                }
-                catch
-                {
-                    logger.RaiseError("gltf-pipeline module not found.", 1);
-                    logger.RaiseError("The exported file wasn't compressed.");
-                }
+                GLTFPipelineUtilities.DoDracoCompression(logger, generateBinary, outputFile);
             }
 
             logger.ReportProgressChanged(100);

--- a/SharedProjects/Utilities/Extensions.projitems
+++ b/SharedProjects/Utilities/Extensions.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ColorExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ArrayExtension.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GLTFPipelineUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ILoggingProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonTextWriterBounded.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonTextWriterOptimized.cs" />

--- a/SharedProjects/Utilities/GLTFPipelineUtilities.cs
+++ b/SharedProjects/Utilities/GLTFPipelineUtilities.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Utilities
+{
+    class GLTFPipelineUtilities
+    {
+        public static bool IsGLTFPipelineInstalled()
+        {
+            try
+            {
+                Process gltfPipeline = new Process();
+                gltfPipeline.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                gltfPipeline.StartInfo.FileName = "cmd.exe";
+                gltfPipeline.StartInfo.Arguments = "/C echo \"Checking for gltf-pipeline installation\" && gltf-pipeline --version";
+                
+                gltfPipeline.Start();
+                gltfPipeline.WaitForExit();
+
+                return gltfPipeline.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static void DoDracoCompression(ILoggingProvider logger, bool generateBinary, string outputFile)
+        {
+            Action onError = delegate
+                {
+                    logger.RaiseError("gltf-pipeline module not found.", 1);
+                    logger.RaiseError("The exported file wasn't compressed.");
+                };
+            try
+            {
+                Process gltfPipeline = new Process();
+
+                // Hide the cmd window that show the gltf-pipeline result
+                //gltfPipeline.StartInfo.UseShellExecute = false;
+                //gltfPipeline.StartInfo.CreateNoWindow = true;
+                gltfPipeline.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+
+                string arg;
+                if (generateBinary)
+                {
+                    string outputGlbFile = Path.ChangeExtension(outputFile, "glb");
+                    arg = $"/C gltf-pipeline -i {outputGlbFile} -o {outputGlbFile} -d";
+                }
+                else
+                {
+                    string outputGltfFile = Path.ChangeExtension(outputFile, "gltf");
+                    arg = $"/C gltf-pipeline -i {outputGltfFile} -o {outputGltfFile} -d -s";
+                }
+                gltfPipeline.StartInfo.FileName = "cmd.exe";
+                gltfPipeline.StartInfo.Arguments = arg;
+
+                gltfPipeline.Start();
+                gltfPipeline.WaitForExit();
+
+                if (gltfPipeline.ExitCode != 0)
+                {
+                    onError();
+                }
+            }
+            catch
+            {
+                onError();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix draco compression gltf-pipeline launcher to no longer require a cmd script. Opens cmd prompt to execute "gltf-pipeline" npm module to check if gltf-pipeline is installed, and during compression