### PR TITLE
fix an issue when texture path of multi export item where loaded/saved

### DIFF
--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -398,7 +398,7 @@ namespace Max2Babylon
             try
             {                
                 string modelAbsolutePath = multiExport ? exportItem.ExportFilePathAbsolute : txtModelPath.Text;
-                string textureExportPath = multiExport ? exportItem.ExportTexturesesFolderPath : txtTexturesPath.Text;
+                string textureExportPath = multiExport ? exportItem.ExportTexturesesFolderAbsolute : txtTexturesPath.Text;
 
                 var scaleFactorParsed = 1.0f;
                 var textureQualityParsed = 100L;

--- a/3ds Max/Max2Babylon/Forms/MultiExportForm.cs
+++ b/3ds Max/Max2Babylon/Forms/MultiExportForm.cs
@@ -52,7 +52,7 @@ namespace Max2Babylon
             row.Cells[1].Value = item.LayersToString(item.Layers);
             row.Cells[2].Value = item.NodeName;
             row.Cells[3].Value = item.ExportFilePathAbsolute;
-            row.Cells[4].Value = item.ExportTexturesesFolderPath;
+            row.Cells[4].Value = item.ExportTexturesesFolderAbsolute;
             Refresh();
         }
 
@@ -79,7 +79,7 @@ namespace Max2Babylon
         {
             ExportItem item = new ExportItem(exportItemList.OutputFileExtension);
             item.SetExportFilePath(GetUniqueExportPath(exportPath));
-            item.SetExportTexturesFolderPath(item.ExportTexturesesFolderPath);
+            item.SetExportTexturesFolderPath(item.ExportTexturesesFolderAbsolute);
             item.Selected = row.Cells[0].Value == null ? Default_ExportItemSelected : (bool)row.Cells[0].Value;
             exportItemList.Add(item);
             return item;
@@ -96,7 +96,7 @@ namespace Max2Babylon
 
             ExportItem item = new ExportItem(exportItemList.OutputFileExtension, nodeHandle);
             item.SetExportFilePath(GetUniqueExportPath(exportPath != null ? exportPath : item.ExportFilePathRelative));
-            item.SetExportTexturesFolderPath(item.ExportTexturesesFolderPath);
+            item.SetExportTexturesFolderPath(item.ExportTexturesesFolderAbsolute);
             item.Selected = row.Cells[0].Value == null ? Default_ExportItemSelected : (bool)row.Cells[0].Value;
             exportItemList.Add(item);
             return item;


### PR DESCRIPTION
the texture path of the multi export item was not resolved correctly converting absolute/relative path