### PR TITLE
fix null ref exception that was exporting unnecessary dummy nodes

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.CustomAttributes.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.CustomAttributes.cs
@@ -30,7 +30,7 @@ namespace Max2Babylon
         public Dictionary<string, object> ExportExtraAttributes(IIGameNode gameNode, BabylonScene babylonScene, List<string> excludeAttributes = null)
         {
             // Retreive the max object
-            ManagedServices.MaxscriptSDK.ExecuteMaxscriptCommand("obj = execute(\"$'" + gameNode.Name + "'\");");
+            ManagedServices.MaxscriptSDK.ExecuteMaxscriptCommand("obj = execute(\"$'" + gameNode.MaxNode.Handle + "'\");");
 
             return _ExportExtraAttributes(gameNode.IGameObject.IPropertyContainer, babylonScene, excludeAttributes);
         }


### PR DESCRIPTION
a reference made trough max script based on the object name was exporting unnecessary dummy objects when two nodes with the same name were presents