### PR TITLE
Fix issue where GLTFTextureInfo still points to old GLTFTexture reference after cache hit

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -201,6 +201,10 @@ namespace Babylon2GLTF
                 {
                     gltf.TexturesList.Add(gltfTexture);
                 }
+                else
+                {
+                    gltfTexture = gltf.TexturesList[GetRegisteredTexture(gltfTexture.name).index];
+                }
 
                 // --------------------------
                 // ------ TextureInfo -------


### PR DESCRIPTION
title is pretty self explanatory, we previously still had the reference to the old GLTFTexture instance after finding a cached texture to use instead in the Dico cache

Addressing #735 