### PR TITLE
Fix texture name when exporting to glTF

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -88,7 +88,7 @@ namespace Babylon2GLTF
                     return null;
                 }
 
-                var destPath = Path.Combine(gltf.OutputFolder, babylonTexture.name);
+                var destPath = Path.Combine(gltf.OutputFolder, name);
                 destPath = Path.ChangeExtension(destPath, validImageFormat);
 
                 name = Path.ChangeExtension(name, validImageFormat);


### PR DESCRIPTION
Fix to https://github.com/BabylonJS/Exporters/issues/739

Use name specified in parameter, if any, rather than input texture name.