### PR TITLE
fix texture export issues

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -346,12 +346,21 @@ namespace Max2Babylon
             var hasAlpha = isTextureOk(alphaTexMap);
             var texture = hasBaseColor ? baseColorTexture : alphaTexture;
 
-            baseColorTextureMapExtension = ".png"; // since we are adding an alpha channel, export as png. This will convert any other input base texture format to PNG.
-            ImageFormat imageFormat = ImageFormat.Png;
+            ImageFormat imageFormat = null;
+            if (hasBaseColor)
+            {
+                imageFormat = TextureUtilities.GetImageFormat(Path.GetExtension(baseColorTexture.Map.FullFilePath));
+            }
+
+            if (hasAlpha || imageFormat == null)
+            {
+                baseColorTextureMapExtension = ".png"; // since we are adding an alpha channel, export as png. This will convert any other input base texture format to PNG.
+                imageFormat = ImageFormat.Png;
+            }
 
             // since we are creating a new texture, give it a unique ID based on the base color and alpha maps.
-            var nameText = (hasBaseColor ? Path.GetFileNameWithoutExtension(baseColorTexture.Map.FullFilePath) + "_" + Path.GetFileNameWithoutExtension(alphaTexture.Map.FullFilePath) : TextureUtilities.ColorToStringName(baseColor));
-            var textureID = hasBaseColor ? texture.GetGuid().ToString() + "_" + alphaTexture.GetGuid().ToString() : string.Format("{0}_{1}", texture.GetGuid().ToString(), nameText);
+            var nameText = (hasBaseColor ? Path.GetFileNameWithoutExtension(baseColorTexture.Map.FullFilePath) + (hasAlpha ?  "_" + Path.GetFileNameWithoutExtension(alphaTexture.Map.FullFilePath) : "") : TextureUtilities.ColorToStringName(baseColor));
+            var textureID = hasBaseColor ? texture.GetGuid().ToString() + (hasAlpha ? "_" + alphaTexture.GetGuid().ToString() : "") : string.Format("{0}_{1}", texture.GetGuid().ToString(), nameText);
 
             if (textureMap.ContainsKey(textureID))
             {
@@ -382,8 +391,19 @@ namespace Max2Babylon
 
             // Set image format
             
-            babylonTexture.name += "_alpha_" + alphaTexture.Name;
-            babylonTexture.name += imageFormat == ImageFormat.Png ? ".png" : ".jpg";
+            if (hasAlpha)
+            {
+                babylonTexture.name += "_alpha_" + alphaTexture.Name;
+            }
+
+            if (imageFormat == ImageFormat.Jpeg)
+            {
+                babylonTexture.name += ".jpg";
+            }
+            else
+            {
+                babylonTexture.name += "." + imageFormat.ToString();
+            }
 
             // Level
             babylonTexture.level = 1.0f;
@@ -396,7 +416,7 @@ namespace Max2Babylon
 
             // --- Merge baseColor and alpha maps ---
 
-            if (exportParameters.writeTextures && baseColorTexture != alphaTexture)
+            if (exportParameters.writeTextures && baseColorTexture != alphaTexture && alphaTexture != null)
             {
                 // Load bitmaps
                 var baseColorBitmap = _loadTexture(baseColorTexMap);

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -327,14 +327,10 @@ namespace Max2Babylon
                         RaiseWarning($"If you don't want material to be in BLEND mode, set diffuse texture Alpha Source to 'None (Opaque)'", 3);
                     }
 
-                    if (baseColorTexture.AlphaSource == MaxConstants.IMAGE_ALPHA_NONE && // 'None (Opaque)'
-                        baseColorTextureMapExtension == ".jpg" || baseColorTextureMapExtension == ".jpeg" || baseColorTextureMapExtension == ".bmp" || baseColorTextureMapExtension == ".png")
-                    {
-                        // Copy base color image
-                        var outTexture = ExportTexture(baseColorTexture, babylonScene);
-                        textureMap[outTexture.Id] = outTexture;
-                        return outTexture;
-                    }
+                    // Copy base color image
+                    var outTexture = ExportTexture(baseColorTexture, babylonScene);
+                    textureMap[outTexture.Id] = outTexture;
+                    return outTexture;
                 }
 
             }

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
@@ -354,15 +354,13 @@ namespace Babylon2GLTF
                         //export textures
                         if (baseColorBitmap != null || babylonTexture.bitmap != null)
                         {
-                            string baseColorTextureName = name + "_baseColor" + ".png"; // TODO - unsafe name, may conflict with another texture name
-                            textureInfoBC = ExportBitmapTexture(gltf, babylonTexture, baseColorBitmap, baseColorTextureName);
+                            textureInfoBC = ExportBitmapTexture(gltf, babylonTexture, baseColorBitmap, null);
                             gltfPbrMetallicRoughness.baseColorTexture = textureInfoBC;
                         }
 
                         if (isTextureOk(babylonStandardMaterial.specularTexture))
                         {
-                            string metallicRoughnessTextureName = name + "_metallicRoughness" + ".jpg"; // TODO - unsafe name, may conflict with another texture name
-                            textureInfoMR = ExportBitmapTexture(gltf, babylonTexture, metallicRoughnessBitmap, metallicRoughnessTextureName);
+                            textureInfoMR = ExportBitmapTexture(gltf, babylonTexture, metallicRoughnessBitmap, null);
                             gltfPbrMetallicRoughness.metallicRoughnessTexture = textureInfoMR;
                         }
 

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -440,9 +440,9 @@ namespace Babylon2GLTF
 
             KHR_texture_transform textureTransform = new KHR_texture_transform
             {
-                offset = new float[] { babylonTexture.uOffset, -babylonTexture.vOffset },
+                offset = new float[] { babylonTexture.uOffset, babylonTexture.vOffset },
                 rotation = angle,
-                scale = new float[] { babylonTexture.uScale, -babylonTexture.vScale },
+                scale = new float[] { babylonTexture.uScale, babylonTexture.vScale },
                 texCoord = babylonTexture.coordinatesIndex
             };
 

--- a/SharedProjects/Utilities/TextureUtilities.cs
+++ b/SharedProjects/Utilities/TextureUtilities.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Linq;
 using System.IO;
+using System.Reflection;
 using BabylonExport.Entities;
 using GLTFExport.Entities;
 
@@ -83,6 +85,34 @@ namespace Utilities
                 logger.RaiseError(string.Format("Texture {0} not found.", absolutePath), 3);
                 return null;
             }
+        }
+
+        // https://dejanstojanovic.net/aspnet/2014/june/getting-systemdrawingimagingimageformat-from-a-string/
+        public static ImageFormat GetImageFormat(string extension)
+        {
+            ImageFormat result = null;
+            if (extension == null || extension == "")
+            {
+                return result;
+            }
+
+            if (extension[0] == '.' || extension[0] == ',')
+            {
+                extension = extension.Substring(1);
+            }
+
+            if (extension == "jpg")
+            {
+                extension = "jpeg";
+            }
+
+            PropertyInfo prop = typeof(ImageFormat).GetProperties().Where(p => p.Name.Equals(extension, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
+            if (prop != null)
+            {
+                result = prop.GetValue(prop) as ImageFormat;
+            }
+
+            return result;
         }
 
         public static void CopyTexture(string sourcePath, string destPath, long imageQuality, ILoggingProvider logger)


### PR DESCRIPTION
Combination of fixes:

Remove texture renaming during GLTF export -> output textures now retain the input texture name. followup to #739 

Fix GLTF KHR_Texture_transform export where texture is V inverted. Addressing #738 

Cleanup texture export, change texture format selection to retain texture extension