### PR TITLE
[3dsMax] Fix and enhance support for unit scaling

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -668,6 +668,9 @@ namespace Max2Babylon
 
                     tm_babylon.decompose(s_babylon, q_babylon, t_babylon);
 
+                    // Apply unit conversion factor to meter
+                    t_babylon *= scaleFactorToMeters;
+
                     return new[] { t_babylon.X, t_babylon.Y, t_babylon.Z };
                 });
             }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -837,6 +837,17 @@ namespace Max2Babylon
             // convert from object to local/node space
             vertex.Position = offsetTM.PointTransform(vertex.Position);
 
+            // Apply unit conversion factor to meter
+            // <!>
+            // For some reason the following code is not working (resulting in ugly rigged mesh)
+            // vertex.Position = (vertex.Position.Clone()).MultiplyBy(scaleFactor); // cloning or not give same results
+            // Instead, create Point3 from scratch
+            // </!>
+            vertex.Position = Loader.Global.Point3.Create(
+                vertex.Position[0] * scaleFactorToMeters,
+                vertex.Position[1] * scaleFactorToMeters,
+                vertex.Position[2] * scaleFactorToMeters);
+
             // normal (from object to local/node space)
             vertex.Normal = offsetTM.VectorTransform(vertex.Normal).Normalize;
 
@@ -1042,6 +1053,11 @@ namespace Max2Babylon
             }
             babylonAbstractMesh.scaling = new[] { s_babylon.X, s_babylon.Y, s_babylon.Z };
             babylonAbstractMesh.position = new[] { t_babylon.X, t_babylon.Y, t_babylon.Z };
+
+            // Apply unit conversion factor to meter
+            babylonAbstractMesh.position[0] *= scaleFactorToMeters;
+            babylonAbstractMesh.position[1] *= scaleFactorToMeters;
+            babylonAbstractMesh.position[2] *= scaleFactorToMeters;
         }
 
         private void exportAnimation(BabylonNode babylonNode, IIGameNode maxGameNode)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -323,14 +323,29 @@ namespace Max2Babylon
                     parentBoneIndex = parentIndex,
                     matrix = (parentIndex==-1)?node.GetWorldTM(0).ToArray():node.GetLocalTM(0).ToArray()
                 };
-                
+
+                // Apply unit conversion factor to meter
+                // Affect translation only
+                bone.matrix[12] *= scaleFactorToMeters;
+                bone.matrix[13] *= scaleFactorToMeters;
+                bone.matrix[14] *= scaleFactorToMeters;
+
                 if (exportParameters.exportAnimations)
                 {
                     // export its animation
                     var babylonAnimation = ExportMatrixAnimation("_matrix", key =>
                     {
                         IGMatrix mat = node.GetLocalTM(key);
-                        return mat.ToArray();
+
+                        float[] matrix = mat.ToArray();
+
+                        // Apply unit conversion factor to meter
+                        // Affect translation only
+                        matrix[12] *= scaleFactorToMeters;
+                        matrix[13] *= scaleFactorToMeters;
+                        matrix[14] *= scaleFactorToMeters;
+
+                        return matrix;
                     },
                     false); // Do not remove linear animation keys for bones
 

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -30,7 +30,7 @@ namespace Max2Babylon
         private bool exportNonAnimated;
 
         public static string exporterVersion = "Custom.Build.Version";
-        public float scaleFactor = 1.0f;
+        public float scaleFactorToMeters = 1.0f;
 
         public const int MaxSceneTicksPerSecond = 4800; //https://knowledge.autodesk.com/search-result/caas/CloudHelp/cloudhelp/2016/ENU/MAXScript-Help/files/GUID-141213A1-B5A8-457B-8838-E602022C8798-htm.html
 
@@ -264,7 +264,8 @@ namespace Max2Babylon
             RaiseMessage($"Exportation started: {fileExportString}", Color.Blue);
 
 
-            this.scaleFactor = Tools.GetScaleFactorToMeters();
+            scaleFactorToMeters = Tools.GetScaleFactorToMeters();
+            RaiseVerbose($"scaleFactorToMeters: {scaleFactorToMeters}");
 
             long quality = exportParameters.txtQuality;
             try

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Animation.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Animation.cs
@@ -213,9 +213,6 @@ namespace Babylon2GLTF
                         if (babylonAnimation.property == "position")
                         {
                             outputValues[2] *= -1;
-                            outputValues[0] *= exportParameters.scaleFactor;
-                            outputValues[1] *= exportParameters.scaleFactor;
-                            outputValues[2] *= exportParameters.scaleFactor;
                         }
                         else if (babylonAnimation.property == "rotationQuaternion")
                         {
@@ -300,7 +297,6 @@ namespace Babylon2GLTF
                     
                     // Switch coordinate system at object level
                     translationBabylon.Z *= -1;
-                    translationBabylon *= exportParameters.scaleFactor;
                     rotationQuatBabylon.X *= -1;
                     rotationQuatBabylon.Y *= -1;
 

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -71,8 +71,6 @@ namespace Babylon2GLTF
                 globalVertex.Position.Z *= -1;
                 globalVertex.Normal.Z *= -1;
 
-                globalVertex.Position *= exportParameters.scaleFactor;
-
                 if (hasUV)
                 {
                     globalVertex.UV = BabylonVector2.FromArray(babylonMesh.uvs, indexVertex);

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Skin.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Skin.cs
@@ -33,7 +33,6 @@ namespace Babylon2GLTF
                     var rotationQuatBabylon = new BabylonQuaternion();
                     var scale = new BabylonVector3();
                     boneLocalMatrix.decompose(scale, rotationQuatBabylon, translationBabylon);
-                    translationBabylon *= exportParameters.scaleFactor;
                     translationBabylon.Z *= -1;
                     rotationQuatBabylon.X *= -1;
                     rotationQuatBabylon.Y *= -1;

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.cs
@@ -537,9 +537,6 @@ namespace Babylon2GLTF
 
                 // Switch coordinate system at object level
                 gltfNode.translation[2] *= -1;
-                gltfNode.translation[0] *= exportParameters.scaleFactor;
-                gltfNode.translation[1] *= exportParameters.scaleFactor;
-                gltfNode.translation[2] *= exportParameters.scaleFactor;
                 gltfNode.rotation[0] *= -1;
                 gltfNode.rotation[1] *= -1;
             }


### PR DESCRIPTION
Fix issue #746 

Add support for unit scaling when exporting to babylon. Previously only glTF export was supported.
Fix unit scaling when exporting to glTF.

In 3dsMax, when switching unit system, all objects in the scene are scaled accordingly.
Ex:
1 generic unit in a meter unit system is equal to 1m
After switching unit system to centimeter, the same 1 generic unit is equal to 1cm
