### PR TITLE
[Maya] Add support for unit scaling

### DIFF
--- a/Maya/Exporter/BabylonExporter.Animation.cs
+++ b/Maya/Exporter/BabylonExporter.Animation.cs
@@ -90,6 +90,11 @@ namespace Maya2Babylon
                 rotationQuaternion[0] *= -1;
                 rotationQuaternion[1] *= -1;
 
+                // Apply unit conversion factor to meter
+                position[0] *= scaleFactorToMeters;
+                position[1] *= scaleFactorToMeters;
+                position[2] *= scaleFactorToMeters;
+
                 // create animation key for each property
                 for (int indexAnimation = 0; indexAnimation < babylonAnimationProperties.Length; indexAnimation++)
                 {
@@ -202,27 +207,31 @@ namespace Maya2Babylon
                 //Get the value for each curves
                 MGlobal.executeCommand("keyframe - q -vc -absolute " + animCurv + ";", keysValue);
 
+                // Switch coordinate system at object level
                 if (animCurv.EndsWith("translateZ") || animCurv.EndsWith("rotateX") || animCurv.EndsWith("rotateY"))
                 {
-                    for (int index = 0; index < keysTime.Count; index++)
+                    for (int index = 0; index < keysValue.Count; index++)
                     {
-                        // Switch coordinate system at object level
-                        int key = keysTime[index];
-                        if (animCurvData.valuePerFrame.ContainsKey(key) == false)
-                        {
-                            animCurvData.valuePerFrame.Add(key, (float)keysValue[index] * -1.0f);
-                        }
+                        keysValue[index] *= -1.0f;
                     }
                 }
-                else
+
+                // Apply unit conversion factor to meter
+                if (animCurv.Contains("translate"))
                 {
-                    for (int index = 0; index < keysTime.Count; index++)
+                    for (int index = 0; index < keysValue.Count; index++)
                     {
-                        int key = keysTime[index];
-                        if (animCurvData.valuePerFrame.ContainsKey(key) == false)
-                        {
-                            animCurvData.valuePerFrame.Add(key, (float)keysValue[index]);
-                        }
+                        keysValue[index] *= scaleFactorToMeters;
+                    }
+                }
+
+                // Store data
+                for (int index = 0; index < keysTime.Count; index++)
+                {
+                    int key = keysTime[index];
+                    if (animCurvData.valuePerFrame.ContainsKey(key) == false)
+                    {
+                        animCurvData.valuePerFrame.Add(key, (float)keysValue[index]);
                     }
                 }
             }
@@ -415,6 +424,11 @@ namespace Maya2Babylon
             position[2] *= -1;
             rotationQuaternion[0] *= -1;
             rotationQuaternion[1] *= -1;
+
+            // Apply unit conversion factor to meter
+            position[0] *= scaleFactorToMeters;
+            position[1] *= scaleFactorToMeters;
+            position[2] *= scaleFactorToMeters;
 
             // The composed matrix
             return BabylonMatrix.Compose(new BabylonVector3(scaling[0], scaling[1], scaling[2]),   // scaling

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -849,6 +849,11 @@ namespace Maya2Babylon
             point.z *= -1;
             normal.z *= -1;
 
+            // Apply unit conversion factor to meter
+            point.x *= scaleFactorToMeters;
+            point.y *= scaleFactorToMeters;
+            point.z *= scaleFactorToMeters;
+
             var vertex = new GlobalVertex
             {
                 BaseIndex = vertexIndexGlobal,
@@ -1310,6 +1315,11 @@ namespace Maya2Babylon
                             // Switch coordinate system at object level
                             position.z *= -1;
                             normal.z *= -1;
+
+                            // Apply unit conversion factor to meter
+                            position.x *= scaleFactorToMeters;
+                            position.y *= scaleFactorToMeters;
+                            position.z *= scaleFactorToMeters;
 
                             GlobalVertex vertex = new GlobalVertex
                             {

--- a/Maya/Exporter/BabylonExporter.Node.cs
+++ b/Maya/Exporter/BabylonExporter.Node.cs
@@ -79,6 +79,11 @@ namespace Maya2Babylon
             rotation[0] *= -1;
             rotation[1] *= -1;
             rotationOrder = Tools.InvertRotationOrder(rotationOrder);
+
+            // Apply unit conversion factor to meter
+            position[0] *= scaleFactorToMeters;
+            position[1] *= scaleFactorToMeters;
+            position[2] *= scaleFactorToMeters;
         }
 
         private void GetTransform(MFnTransform mFnTransform, ref float[] position)
@@ -89,6 +94,11 @@ namespace Maya2Babylon
 
             // Switch coordinate system at object level
             position[2] *= -1;
+
+            // Apply unit conversion factor to meter
+            position[0] *= scaleFactorToMeters;
+            position[1] *= scaleFactorToMeters;
+            position[2] *= scaleFactorToMeters;
         }
     }
 }

--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -32,6 +32,7 @@ namespace Maya2Babylon
         private static List<string> defaultCameraNames = new List<string>(new string[] { "persp", "top", "front", "side" });
 
         public static string exporterVersion = "Custom.Build.Version";
+        public float scaleFactorToMeters = 1.0f;
 
         /// <summary>
         /// Export to file
@@ -70,6 +71,11 @@ namespace Maya2Babylon
             RaiseMessage("Export started", Color.Blue);
             var progression = 0.0f;
             ReportProgressChanged(progression);
+
+            // In Maya, system unit does not influence model size
+            // Ex: 1 meter is converted to 100 cm: the scene is not shrinked
+            // All values are retreived from API as centimeters regardless of current unit
+            scaleFactorToMeters = 0.01f;
 
             // Store export options
             this.isBabylonExported = exportParameters.outputFormat == "babylon" || exportParameters.outputFormat == "binary babylon";
@@ -339,7 +345,7 @@ namespace Maya2Babylon
             }
 
             var sceneScaleFactor = exportParameters.scaleFactor;
-            if (exportParameters.scaleFactor != 1.0f)
+            if (sceneScaleFactor != 1.0f)
             {
                 RaiseMessage(String.Format("A root node is added to globally scale the scene by {0}", sceneScaleFactor), 1);
 


### PR DESCRIPTION
Fix issues #694 and #687 

- Add support for unit scaling to export at meter scale (instead of centimeter as it used to)
- Refactor animation data retrieval from curves

In Maya, when switching unit system, objects in the scene are unaffected.
Ex:
1 generic unit in a meter unit system is equal to 1m
After switching unit system to centimeter, the same 1 generic unit is equal to 100cm

Thus, the support for unit scaling in Maya is straight forward.
All values retreived from Maya API are in centimeter.
The exporter is converting those values to meter.
The current unit system in Maya does not matter during export process.

Also, note that Maya documentation discourages to modify the unit system:

> You can change the default working units in Maya, which are in metric, but it is recommended to leave them unchanged as some tools in Maya have a set type, for example, Nucleus and Bifrost are hard-coded so that 1 unit = 1 meter, regardless of working units. Instead, do not change Maya's default working units and adjust your grid to align with the scale of the project you are working on.

The exporter will work fine regardless of current unit system but it's not the case for all plugins.

The refactor aims to:
- first edit animation curves data for specific cases
- then store data for all curves