### PR TITLE
[Maya] Fix light orientation in glTF

### DIFF
--- a/Maya/Exporter/BabylonExporter.Camera.cs
+++ b/Maya/Exporter/BabylonExporter.Camera.cs
@@ -88,25 +88,8 @@ namespace Maya2Babylon
             // User custom attributes
             babylonCamera.metadata = ExportCustomAttributeFromTransform(mFnTransform);
 
-            // Position / rotation
-            RaiseVerbose("BabylonExporter.Camera | ExportTransform", 2);
-            float[] position = null;
-            float[] rotationQuaternion = null;
-            float[] rotation = null;
-            float[] scaling = null;
-            var rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
-            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling);
-            babylonCamera.position = position;
-            babylonCamera.scaling = scaling;
-            if (_exportQuaternionsInsteadOfEulers)
-            {
-                babylonCamera.rotationQuaternion = rotationQuaternion;
-            }
-            else
-            {
-                babylonCamera.rotation = rotation;
-            }
-            
+            // Position / rotation / scaling
+            ExportTransform(babylonCamera, mFnTransform);
 
             // Field of view of babylon is the vertical one
             babylonCamera.fov = (float)mFnCamera.verticalFieldOfView;

--- a/Maya/Exporter/BabylonExporter.Light.cs
+++ b/Maya/Exporter/BabylonExporter.Light.cs
@@ -128,11 +128,8 @@ namespace Maya2Babylon
             // User custom attributes
             babylonLight.metadata = ExportCustomAttributeFromTransform(mFnTransform);
 
-            // Position
-            //RaiseVerbose("BabylonExporter.Light | ExportTransform", 2);
-            float[] position = null;
-            GetTransform(mFnTransform, ref position);
-            babylonLight.position = position;
+            // Position / rotation / scaling
+            ExportTransform(babylonLight, mFnTransform);
 
             // Direction
             var vDir = new MVector(0, 0, -1);

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -1070,29 +1070,6 @@ namespace Maya2Babylon
             ExportHierarchy(babylonAbstractMesh, mFnTransform);
         }
 
-        private void ExportTransform(BabylonAbstractMesh babylonAbstractMesh, MFnTransform mFnTransform)
-        {
-            // Position / rotation / scaling
-            RaiseVerbose("BabylonExporter.Mesh | ExportTransform", 2);
-            float[] position = null;
-            float[] rotationQuaternion = null;
-            float[] rotation = null;
-            float[] scaling = null;
-            BabylonVector3.EulerRotationOrder rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
-            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling);
-
-            babylonAbstractMesh.position = position;
-            if (_exportQuaternionsInsteadOfEulers)
-            {
-                babylonAbstractMesh.rotationQuaternion = rotationQuaternion;
-            }
-            else
-            {
-                babylonAbstractMesh.rotation = rotation;
-            }
-            babylonAbstractMesh.scaling = scaling;
-        }
-
         /// <summary>
         /// 
         /// </summary>

--- a/Maya/Exporter/BabylonExporter.Node.cs
+++ b/Maya/Exporter/BabylonExporter.Node.cs
@@ -60,6 +60,29 @@ namespace Maya2Babylon
             }
         }
 
+        private void ExportTransform(BabylonNode babylonNode, MFnTransform mFnTransform)
+        {
+            // Position / rotation / scaling
+            RaiseVerbose("BabylonExporter.Node | ExportTransform", 2);
+            float[] position = null;
+            float[] rotationQuaternion = null;
+            float[] rotation = null;
+            float[] scaling = null;
+            BabylonVector3.EulerRotationOrder rotationOrder = BabylonVector3.EulerRotationOrder.XYZ;
+            GetTransform(mFnTransform, ref position, ref rotationQuaternion, ref rotation, ref rotationOrder, ref scaling);
+
+            babylonNode.position = position;
+            if (_exportQuaternionsInsteadOfEulers)
+            {
+                babylonNode.rotationQuaternion = rotationQuaternion;
+            }
+            else
+            {
+                babylonNode.rotation = rotation;
+            }
+            babylonNode.scaling = scaling;
+        }
+
         private void GetTransform(MFnTransform mFnTransform, ref float[] position, ref float[] rotationQuaternion, ref float[] rotation, ref BabylonVector3.EulerRotationOrder rotationOrder, ref float[] scaling)
         {
             var transformationMatrix = new MTransformationMatrix(mFnTransform.transformationMatrix);
@@ -79,21 +102,6 @@ namespace Maya2Babylon
             rotation[0] *= -1;
             rotation[1] *= -1;
             rotationOrder = Tools.InvertRotationOrder(rotationOrder);
-
-            // Apply unit conversion factor to meter
-            position[0] *= scaleFactorToMeters;
-            position[1] *= scaleFactorToMeters;
-            position[2] *= scaleFactorToMeters;
-        }
-
-        private void GetTransform(MFnTransform mFnTransform, ref float[] position)
-        {
-            var transformationMatrix = new MTransformationMatrix(mFnTransform.transformationMatrix);
-
-            position = transformationMatrix.getTranslation();
-
-            // Switch coordinate system at object level
-            position[2] *= -1;
 
             // Apply unit conversion factor to meter
             position[0] *= scaleFactorToMeters;


### PR DESCRIPTION
Fix issue #696 for Maya.

See PR #754 for 3dsMax.

ExportTransform method is used for lights and cameras as well as meshes:
1. for consistency
2. to update the rotation attribute of babylon objects. This way, the rotation is exported in glTF.

The ExportTransform method code is moved from Mesh.cs to Node.cs