### PR TITLE
Patch for 3DSMax hair and fur modifier

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/MaxGLTFMaterialExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/MaxGLTFMaterialExporter.cs
@@ -40,6 +40,11 @@ internal class MaxGLTFMaterialExporter : IGLTFMaterialExporter
     {
         gltfMaterial = null;
         IIGameMaterial gameMtl = babylonMaterial.maxGameMaterial;
+        if (gameMtl == null || gameMtl.MaxMaterial == null)
+        {
+            return false;
+        }
+
         IMtl maxMtl = gameMtl.MaxMaterial;
 
         IMaxMaterialExporter materialExporter;

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
@@ -565,6 +565,25 @@ namespace Babylon2GLTF
                     }
                 }
             }
+            else if (babylonMaterial.GetType() == typeof(BabylonFurMaterial))
+            {
+                // TODO - Implement proper handling of BabylonFurMaterial once gLTF spec has support
+                var babylonPBRFurMaterial = babylonMaterial as BabylonFurMaterial;
+
+                gltfMaterial = new GLTFMaterial
+                {
+                    name = name
+                };
+                gltfMaterial.id = babylonMaterial.id;
+                gltfMaterial.index = gltf.MaterialsList.Count;
+                gltf.MaterialsList.Add(gltfMaterial);
+
+                //Custom user properties
+                if (babylonPBRFurMaterial.metadata != null && babylonPBRFurMaterial.metadata.Count != 0)
+                {
+                    gltfMaterial.extras = babylonPBRFurMaterial.metadata;
+                }
+            }
             else
             {
                 logger.RaiseWarning("GLTFExporter.Material | Unsupported material type: " + babylonMaterial.GetType(), 2);


### PR DESCRIPTION
See issue #766:

Support for the "hair and fur" world modifier was added to the Max2Babylon exporter. However, functionality was never extended to GLTFExporter.

In fact when trying to export from 3dsMax 2020 using the exporter to gltf or glb format, a NullReferenceException is thrown. 

Add check to gameMtl to prevent exception and the generate default material placeholder for the object with hair and fur.  There is additional work to be done to make this fully functional:
- Track, in memory the mapping of the base material that is applied to the model beneath the hair and fur world modifier.
- Wait for gltf extension support for hair and fur .
