### PR TITLE
Remove Extra Serialized Bits

### DIFF
--- a/Maya/Forms/ExporterForm.cs
+++ b/Maya/Forms/ExporterForm.cs
@@ -402,7 +402,7 @@ namespace Maya2Babylon.Forms
                     this.saveFileDialog.Filter = "glTF files|*.gltf";
                     chkDracoCompression.Enabled = gltfPipelineInstalled;
                     chkNoAutoLight.Enabled = false;
-                    chkNoAutoLight.Checked = false;
+                    chkNoAutoLight.Checked = true;
                     chkFullPBR.Enabled = false;
                     chkFullPBR.Checked = false;
                     chkDefaultSkybox.Enabled = false;
@@ -416,7 +416,7 @@ namespace Maya2Babylon.Forms
                     this.saveFileDialog.Filter = "glb files|*.glb";
                     chkDracoCompression.Enabled = gltfPipelineInstalled;
                     chkNoAutoLight.Enabled = false;
-                    chkNoAutoLight.Checked = false;
+                    chkNoAutoLight.Checked = true;
                     chkFullPBR.Enabled = false;
                     chkFullPBR.Checked = false;
                     chkDefaultSkybox.Enabled = false;

--- a/SharedProjects/GltfExport.Entities/GLTFProperty.cs
+++ b/SharedProjects/GltfExport.Entities/GLTFProperty.cs
@@ -14,12 +14,12 @@ namespace GLTFExport.Entities
 
         public bool ShouldSerializeextensions()
         {
-            return (this.extensions != null);
+            return this.extensions != null && this.extensions.Count > 0;
         }
 
         public bool ShouldSerializeextras()
         {
-            return (this.extras != null);
+            return (this.extras != null && this.extras.Count > 0);
         }
     }
 }


### PR DESCRIPTION
removes 'Default Light' always being exported to gltf. removed serialization of empty scenes.extensions and scenes.extras object

Fixes #777 