### PR TITLE
Fix maya animation rotation interpolation

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -496,7 +496,7 @@ namespace Max2Babylon
             }
         }
 
-        private float[] weightedLerp(int frame0, int frame1, int frame2, float[] value0, float[] value2)
+        private float[] weightedLerp(float frame0, float frame1, float frame2, float[] value0, float[] value2)
         {
             double weight2 = (frame1 - frame0) / (double)(frame2 - frame0);
             double weight0 = 1 - weight2;

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Animation.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Animation.cs
@@ -459,7 +459,7 @@ namespace Babylon2GLTF
             }
 
             var influencesPerFrame = _getTargetManagerAnimationsData(babylonMorphTargetManager);
-            var frames = new List<int>(influencesPerFrame.Keys);
+            var frames = new List<float>(influencesPerFrame.Keys);
 
             var framesInRange = frames.Where(frame => frame >= startFrame && frame <= endFrame).ToList();
             framesInRange.Sort(); // Mandatory to sort otherwise gltf loader of babylon doesn't understand
@@ -611,10 +611,10 @@ namespace Babylon2GLTF
         /// for animation2, the value associated to key=0 is equal to the one at key=50 since 0 is out of range [50, 100] (same for key=25)</example>
         /// <param name="babylonMorphTargetManager"></param>
         /// <returns>A map which for each frame, gives the influence value of all targets</returns>
-        private Dictionary<int, List<float>> _getTargetManagerAnimationsData(BabylonMorphTargetManager babylonMorphTargetManager)
+        private Dictionary<float, List<float>> _getTargetManagerAnimationsData(BabylonMorphTargetManager babylonMorphTargetManager)
         {
             // Merge all keys into a single set (no duplicated frame)
-            var mergedFrames = new HashSet<int>();
+            var mergedFrames = new HashSet<float>();
             foreach (var babylonMorphTarget in babylonMorphTargetManager.targets)
             {
                 if (babylonMorphTarget.animations != null)
@@ -628,7 +628,7 @@ namespace Babylon2GLTF
             }
 
             // For each frame, gives the influence value of all targets (gltf structure)
-            var influencesPerFrame = new Dictionary<int, List<float>>();
+            var influencesPerFrame = new Dictionary<float, List<float>>();
             foreach (var frame in mergedFrames)
             {
                 influencesPerFrame.Add(frame, new List<float>());
@@ -636,7 +636,7 @@ namespace Babylon2GLTF
             foreach (var babylonMorphTarget in babylonMorphTargetManager.targets)
             {
                 // For a given target, for each frame, gives the influence value of the target (babylon structure)
-                var influencePerFrameForTarget = new Dictionary<int, float>();
+                var influencePerFrameForTarget = new Dictionary<float, float>();
 
                 if (babylonMorphTarget.animations != null && babylonMorphTarget.animations.Length > 0)
                 {

--- a/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
@@ -7,7 +7,7 @@ namespace BabylonExport.Entities
     public class BabylonAnimationKey : IComparable<BabylonAnimationKey>, ICloneable
     {
         [DataMember]
-        public int frame { get; set; }
+        public float frame { get; set; }
 
         [DataMember]
         public float[] values { get; set; }

--- a/SharedProjects/BabylonExport.Entities/BabylonQuaternion.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonQuaternion.cs
@@ -223,5 +223,6 @@ namespace BabylonExport.Entities
 
             return result;
         }
+
     }
 }

--- a/SharedProjects/Utilities/MathUtilities.cs
+++ b/SharedProjects/Utilities/MathUtilities.cs
@@ -12,6 +12,37 @@ namespace Utilities
             return min + (max - min) * t;
         }
 
+        public static float LerpEulerAngle(float min, float max, float t)
+        {
+            while(min < 0 || max < 0)
+            {
+                min += 360.0f;
+                max += 360.0f;
+            }
+
+            return min + (max - min) * t;
+        }
+
+        public static float[] Lerp(float[] minArray, float[] maxArray, float t)
+        {
+            float[] res = new float[minArray.Length];
+            for (int index = 0; index < minArray.Length; index++)
+            {
+                res[index] = MathUtilities.Lerp(minArray[index], maxArray[index], t);
+            }
+            return res;
+        }
+
+        public static float[] LerpEulerAngle(float[] minArray, float[] maxArray, float t)
+        {
+            float[] res = new float[minArray.Length];
+            for (int index = 0; index < minArray.Length; index++)
+            {
+                res[index] = MathUtilities.LerpEulerAngle(minArray[index], maxArray[index], t);
+            }
+            return res;
+        }
+
         public static int RoundToInt(float f)
         {
             return Convert.ToInt32(Math.Round(f, MidpointRounding.AwayFromZero));


### PR DESCRIPTION
This Pull Request adds logic to the keyframe exporting behavior of the maya animation exporter. Rotation animations with keyframe differences that exceed a certain threshold are interpolated linarly.