### PR TITLE
Fix morph target animations being exported when ExportAnimations is disabed.

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -520,12 +520,15 @@ namespace Max2Babylon
                                 }
 
                                 // Animations
-                                var animations = new List<BabylonAnimation>();
-                                var morphWeight = morpher.GetMorphWeight(i);
-                                ExportFloatGameController(morphWeight, "influence", animations);
-                                if (animations.Count > 0)
+                                if (exportParameters.exportAnimations)
                                 {
-                                    babylonMorphTarget.animations = animations.ToArray();
+                                    var animations = new List<BabylonAnimation>();
+                                    var morphWeight = morpher.GetMorphWeight(i);
+                                    ExportFloatGameController(morphWeight, "influence", animations);
+                                    if (animations.Count > 0)
+                                    {
+                                        babylonMorphTarget.animations = animations.ToArray();
+                                    }
                                 }
                             }
                         }

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -515,7 +515,7 @@ namespace Maya2Babylon
             if (optimizeVertices && hasMorphTarget)
             {
                 optimizeVertices = false;
-                RaiseWarning("Unable to optimize a mesh with morph targets. Disabling optimization for this mesh.");
+                RaiseWarning("Unable to optimize a mesh with morph targets. Disabling optimization for this mesh.", 2);
             }
 
             // Compute normals
@@ -1350,7 +1350,10 @@ namespace Maya2Babylon
                         }
 
                         // Animation
-                        babylonMorphTarget.animations = GetAnimationsInfluence(blendShapeDeformer.name, weightIndex).ToArray();
+                        if (exportParameters.exportAnimations)
+                        {
+                            babylonMorphTarget.animations = GetAnimationsInfluence(blendShapeDeformer.name, weightIndex).ToArray();
+                        }
                     }
 
                 }


### PR DESCRIPTION
Add check for ExportAnimations export flag when exporting morph target animation tracks

Fixes #778 