### PR TITLE
Fix maya light orientation export

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Light.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Light.cs
@@ -147,7 +147,7 @@ namespace Max2Babylon
                     var targetPosition = targetWm.Translation;
 
                     var direction = targetPosition.Subtract(position).Normalize;
-                    babylonLight.direction = new[] { direction.X, direction.Y, direction.Z };
+                    babylonLight.direction = new[]   { direction.X, direction.Y, direction.Z };
                 }
                 else
                 {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Light.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Light.cs
@@ -65,10 +65,9 @@ namespace Max2Babylon
             // Export the custom attributes of this light
             babylonLight.metadata = ExportExtraAttributes(lightNode, babylonScene);
 
-            // If the light has a children and the export is to babylon, add a dummy
             // To preserve the position/rotation and the hierarchy, we create a dummy that will contains as direct children the light and the light children
             // The light will have no children. The dummy will contains the position and rotation animations.
-            bool createDummy = isBabylonExported && (lightNode.ChildCount > 0);
+            bool createDummy = lightNode.ChildCount > 0;
             BabylonNode dummy = null;
             if (createDummy)
             {
@@ -76,6 +75,7 @@ namespace Max2Babylon
                 dummy.name = "_" + dummy.name + "_";
                 babylonLight.id = Guid.NewGuid().ToString();
                 babylonLight.parentId = dummy.id;
+                babylonLight.hasDummy = true;
             }
             else
             {

--- a/Maya/Exporter/BabylonExporter.CustomAttributes.cs
+++ b/Maya/Exporter/BabylonExporter.CustomAttributes.cs
@@ -48,7 +48,14 @@ namespace Maya2Babylon
             MStringArray customAttributeNamesMStringArray = new MStringArray();
             Dictionary<string, object> customsAttributes = new Dictionary<string, object>();
 
-            MGlobal.executeCommand($"listAttr -ud {objectName}", customAttributeNamesMStringArray);
+            try
+            {
+                MGlobal.executeCommand($"listAttr -ud {objectName}", customAttributeNamesMStringArray);
+            }
+            catch (Exception e)
+            {
+                //do nothing...
+            }
 
             var customAttributeNames = customAttributeNamesMStringArray.Where((attributeName) => { return !_DisallowedCustomAttributeNames.Contains(attributeName); });
 

--- a/SharedProjects/BabylonExport.Entities/BabylonLight.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonLight.cs
@@ -53,6 +53,8 @@ namespace BabylonExport.Entities
         [DataMember]
         public int? falloffType { get; set; }
 
+        public bool? hasDummy { get; set; }
+
         public BabylonLight()
         {
             diffuse = new[] {1.0f, 1.0f, 1.0f};


### PR DESCRIPTION
This PR makes multiple changes to the light and animation export pipelines to fix situations where lights with a child node are properly represented in scene. If a light in scene is animated, or contains a child node, then it will be encapsulated in a dummy node that will contain the animation or child node hierarchy.

Max implementation was introduced via #754, this PR addresses the same issue for Maya, and updated the Max implementation to use the same criteria.