### PR TITLE
Fix KHR_texture_transform texture transform vScale

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -448,9 +448,9 @@ namespace Babylon2GLTF
 
             KHR_texture_transform textureTransform = new KHR_texture_transform
             {
-                offset = new float[] { babylonTexture.uOffset, babylonTexture.vOffset },
+                offset = new float[] { babylonTexture.uOffset, -babylonTexture.vOffset },
                 rotation = angle,
-                scale = new float[] { babylonTexture.uScale, babylonTexture.vScale },
+                scale = new float[] { babylonTexture.uScale, -babylonTexture.vScale },
                 texCoord = babylonTexture.coordinatesIndex
             };
 


### PR DESCRIPTION
this PR inverts the texture vScale when using the KHR_texture_transform extension, due to babylon using a lower left texture coordinate origin, and glTF expecting a top left origin.