### PR TITLE
Fix GLTFLight serialization fields for node declaration, Fix GLTFLight defaults.

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Light.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Light.cs
@@ -47,7 +47,10 @@ namespace Babylon2GLTF
                     break;
                 case (2): // spot
                     light.type = GLTFLight.LightType.spot.ToString();
-                    light.range = babylonLight.range;
+                    if (babylonLight.range != float.MaxValue)
+                    {
+                        light.range = babylonLight.range;
+                    }
                     light.spot = new GLTFLight.Spot
                     {
                         //innerConeAngle = 0, Babylon doesn't support the innerConeAngle

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Light.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Light.cs
@@ -40,7 +40,10 @@ namespace Babylon2GLTF
             {
                 case (0): // point
                     light.type = GLTFLight.LightType.point.ToString();
-                    light.range = babylonLight.range;
+                    if (babylonLight.range != float.MaxValue)
+                    {
+                        light.range = babylonLight.range;
+                    }
                     break;
                 case (1): // directional
                     light.type = GLTFLight.LightType.directional.ToString();

--- a/SharedProjects/GltfExport.Entities/GLTFLight.cs
+++ b/SharedProjects/GltfExport.Entities/GLTFLight.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using System.Runtime.Serialization;
+using Utilities;
+using System;
 
 namespace GLTFExport.Entities
 {
@@ -20,16 +22,16 @@ namespace GLTFExport.Entities
 
         // Properties used by GLTFextension
         [DataMember]
-        public float[] color { get; set; }
+        public float[] color { get; set; } = new float[3] { 1.0f, 1.0f, 1.0f };
 
         [DataMember]
-        public float intensity { get; set; }
+        public float intensity { get; set; } = 1.0f;
 
         [DataMember]
-        public string type { get; set; }         // ambient, directional, point or spot
+        public string type { get; set; }            // ambient, directional, point or spot
 
         [DataMember]
-        public float? range { get; set; }            // point or spot
+        public float? range { get; set; } = 0.0f;   // point or spot
 
         [DataMember]
         public Spot spot { get; set; }              // spot
@@ -38,6 +40,11 @@ namespace GLTFExport.Entities
         public bool ShouldSerializelight()
         {
             return (this.light != null);
+        }
+
+        public bool ShouldSerializespot()
+        {
+            return (this.spot != null && (this.spot.ShouldSerializeouterConeAngle() || this.spot.ShouldSerializeinnerConeAngle()));
         }
 
         public bool ShouldSerializecolor()
@@ -57,7 +64,7 @@ namespace GLTFExport.Entities
 
         public bool ShouldSerializerange()
         {
-            return (this.range != null);
+            return (this.range != null && this.range != 0.0f);
         }
 
         [DataContract]
@@ -72,12 +79,12 @@ namespace GLTFExport.Entities
 
             public bool ShouldSerializeinnerConeAngle()
             {
-                return (this.innerConeAngle != null);
+                return (this.innerConeAngle != null && this.innerConeAngle != 0.0f);
             }
 
             public bool ShouldSerializeouterConeAngle()
             {
-                return (this.outerConeAngle != null);
+                return (this.outerConeAngle != null && !MathUtilities.IsAlmostEqualTo((float)this.outerConeAngle, (float)Math.PI/4.0f, float.Epsilon));
             }
         }
     }

--- a/SharedProjects/GltfExport.Entities/GLTFLight.cs
+++ b/SharedProjects/GltfExport.Entities/GLTFLight.cs
@@ -31,7 +31,7 @@ namespace GLTFExport.Entities
         public string type { get; set; }            // ambient, directional, point or spot
 
         [DataMember]
-        public float? range { get; set; } = 0.0f;   // point or spot
+        public float? range { get; set; }           // point or spot, undefined = infinite
 
         [DataMember]
         public Spot spot { get; set; }              // spot
@@ -64,7 +64,7 @@ namespace GLTFExport.Entities
 
         public bool ShouldSerializerange()
         {
-            return (this.range != null && this.range != 0.0f);
+            return (this.range != null);
         }
 
         [DataContract]

--- a/SharedProjects/Utilities/ArrayExtension.cs
+++ b/SharedProjects/Utilities/ArrayExtension.cs
@@ -22,7 +22,7 @@ namespace Utilities
             }
             for (var i = 0; i < current.Length; ++i)
             {
-                if (Math.Abs(current[i] - other[i]) > epsilon)
+                if (!MathUtilities.IsAlmostEqualTo(current[i], other[i], epsilon))
                 {
                     return false;
                 }

--- a/SharedProjects/Utilities/MathUtilities.cs
+++ b/SharedProjects/Utilities/MathUtilities.cs
@@ -48,6 +48,11 @@ namespace Utilities
             return Convert.ToInt32(Math.Round(f, MidpointRounding.AwayFromZero));
         }
 
+        public static bool IsAlmostEqualTo(float first, float second, float epsilon)
+        {
+            return Math.Abs(first - second) < epsilon;
+        }
+
         /**
          * Computes a texture transform matrix with a pre-transformation
          */


### PR DESCRIPTION
Fix for issue where GLTF lights are serialized with improper field information in node declaration and lights declaration. updated default values for GLTFLight, updated ShouldSerialze field checks

Fixes #818 