### PR TITLE
Fix for custom attribute serialization for 3dsMax IGameNodes

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.CustomAttributes.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.CustomAttributes.cs
@@ -30,7 +30,7 @@ namespace Max2Babylon
         public Dictionary<string, object> ExportExtraAttributes(IIGameNode gameNode, BabylonScene babylonScene, List<string> excludeAttributes = null)
         {
             // Retreive the max object
-            ManagedServices.MaxscriptSDK.ExecuteMaxscriptCommand("obj = execute(\"$'" + gameNode.MaxNode.Handle + "'\");");
+            ManagedServices.MaxscriptSDK.ExecuteMaxscriptCommand("obj = maxOps.getNodeByHandle " + gameNode.MaxNode.Handle + ";");
 
             return _ExportExtraAttributes(gameNode.IGameObject.IPropertyContainer, babylonScene, excludeAttributes);
         }


### PR DESCRIPTION
This fix changes the invoked 3ds Max Maxscript code used to setup a reference to the current processing IGameNode when exporting custom attributes.

Fixes #817 