### PR TITLE
Fix skeleton hierarchy export where parent bones are culled

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -93,6 +93,13 @@ namespace Max2Babylon
                 return new List<IIGameNode>();
             }
 
+            // Babylon format assumes skeleton root is at origin, add any additional node parents from the lowest common ancestor to the scene root to the skeleton hierarchy.
+            while (lowestCommonAncestor.NodeParent != null)
+            {
+                lowestCommonAncestor = lowestCommonAncestor.NodeParent;
+                allHierarchyNodes.Add(lowestCommonAncestor);
+            }
+
             // starting from the root, sort the nodes by depth first (add the children before the siblings)
             List<IIGameNode> sorted = new List<IIGameNode>();
             Stack<IIGameNode> siblings = new Stack<IIGameNode>();   // keep the siblings in a LIFO list to add them after the children


### PR DESCRIPTION
Fix for issue where skeletons are exported missing parent bone hierarchy, add nodes in hierarchy to world root to skeleton hierarchy

Fixes #823 