### PR TITLE
more fixes to max 2021 tooling

### DIFF
--- a/3ds Max/Max2Babylon/2021/Max2Babylon2021.csproj
+++ b/3ds Max/Max2Babylon/2021/Max2Babylon2021.csproj
@@ -35,7 +35,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;MAX2020</DefineConstants>
+    <DefineConstants>TRACE;MAX2021</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/BabylonJS_Installer/BabylonJS_Installer/Properties/AssemblyInfo.cs
+++ b/BabylonJS_Installer/BabylonJS_Installer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]


### PR DESCRIPTION
Change Max2021 release version compilation symbols. 

Update installer assembly version