### PR TITLE
Added workaround for 3dsMax Boolean operation (and other similar operations) that assign null vertex color in-engine

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -436,8 +436,26 @@ namespace Max2Babylon
 
                 if (hasColor)
                 {
-                    babylonMesh.colors = vertices.SelectMany(v => v.Color.ToArray()).ToArray();
-                    babylonMesh.hasVertexAlpha = hasAlpha;
+                    var colors = vertices.SelectMany(v => v.Color.ToArray()).ToArray();
+
+                    // There is an issue in 3dsMax where certain CSG operations assign a vertex color to the generated geometry.
+                    // this workaround allows us to void our vertex colors if they have all been found to be [0,0,0,0]
+                    bool useVertexColors = false;
+                    for (int i = 0; i < colors.Length; ++i)
+                    {
+                        if (colors[i] != 0.0f)
+                        {
+                            useVertexColors = true;
+                            break;
+                        }
+                    }
+
+                    if (useVertexColors)
+                    {
+                        babylonMesh.colors = colors;
+                        babylonMesh.hasVertexAlpha = hasAlpha;
+                    }
+                    
                 }
 
                 babylonMesh.subMeshes = subMeshes.ToArray();


### PR DESCRIPTION
Fix was targeted towards 3dsMax scene:
[Forum_3dsmax-after-exporting-boolean-object-loses-its-texture.zip](https://github.com/BabylonJS/Exporters/files/4853658/Forum_3dsmax-after-exporting-boolean-object-loses-its-texture.zip)


https://forum.babylonjs.com/t/3dsmax-after-exporting-boolean-object-loses-its-texture/12004/3

Fix checks vertex color buffer for non-zero values, and only exports if a value is non-zero.