### PR TITLE
Fix animation tracks mising in gltf export

### DIFF
--- a/Maya/Exporter/BabylonExporter.Animation.cs
+++ b/Maya/Exporter/BabylonExporter.Animation.cs
@@ -1143,7 +1143,7 @@ namespace Maya2Babylon
                     }
                     else
                     {
-                        interpolatedKey.values = new List<float>(firstKeyAfterFrom.values).ToArray();
+                        interpolatedKey.values = new List<float>(lastKeyBeforeFrom.values).ToArray();
                     }
                     keysInRange.Insert(0, interpolatedKey);
                 }

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Animation.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Animation.cs
@@ -153,21 +153,25 @@ namespace Babylon2GLTF
             var babylonAnimations = new List<BabylonAnimation>();
             if (animationGroup != null)
             {
-                var targetedAnimation = animationGroup.targetedAnimations.FirstOrDefault(animation => animation.targetId == babylonNode.id);
-                if (targetedAnimation != null)
+                var targetedAnimations = animationGroup.targetedAnimations.Where(animation => animation.targetId == babylonNode.id);
+                foreach (var targetedAnimation in targetedAnimations)
                 {
                     babylonAnimations.Add(targetedAnimation.animation);
                 }
             }
 
             // Do not include the node animations if a provided animation group already includes them.
-            if (babylonNode.animations != null && babylonAnimations.Count <= 0)
+            if (babylonAnimations.Count <= 0)
             {
-                babylonAnimations.AddRange(babylonNode.animations);
-            }
-            if (babylonNode.extraAnimations != null)
-            {
-                babylonAnimations.AddRange(babylonNode.extraAnimations);
+                if (babylonNode.animations != null)
+                {
+                    babylonAnimations.AddRange(babylonNode.animations);
+                }
+
+                if (babylonNode.extraAnimations != null)
+                {
+                    babylonAnimations.AddRange(babylonNode.extraAnimations);
+                }
             }
 
             // Filter animations to only keep TRS ones


### PR DESCRIPTION
Fix for issue where glTF exported animation groups only contained a single animation track per node. Fix addresses this by changing node animation-group track retrieval logic to retrieve all animation tracks for a given node instead of just the first.

Fixes #851 