### PR TITLE
Fix Maya hangs when export is invoked via MELscript

### DIFF
--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -518,7 +518,6 @@ namespace Maya2Babylon
 
         public void CheckCancelled()
         {
-            Application.DoEvents();
             if (IsCancelled)
             {
                 throw new OperationCanceledException();

--- a/Maya/MayaPlugin.cs
+++ b/Maya/MayaPlugin.cs
@@ -259,7 +259,6 @@ namespace Maya2Babylon
                         catch
                         {
                         }
-                        Application.DoEvents();
                     };
 
                     exporterInstance.OnWarning += (error, rank) =>
@@ -271,7 +270,6 @@ namespace Maya2Babylon
                         catch
                         {
                         }
-                        Application.DoEvents();
                     };
 
                     exporterInstance.OnMessage += (message, color, rank, emphasis) =>
@@ -283,7 +281,6 @@ namespace Maya2Babylon
                         catch
                         {
                         }
-                        Application.DoEvents();
                     };
 
                     exporterInstance.Export(ScriptExportParameters);


### PR DESCRIPTION
Fix for issue where exporter hangs when invoked via MELScript. Remove Application.DoEvents() call from  MEL logging implementation and cancel callback