### PR TITLE
 If a "#" is in the generated texture filename it creates problems wi…

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -501,6 +501,10 @@ namespace Max2Babylon
                     }
                 }
 
+                // If there is a "#" in the generated texture filename it causes problems with Exporter webserver
+                // when viewing the final exported project. This converts any troublesome characters to underscores
+                babylonTexture.name = PathUtilities.VerifyLegalFileName(babylonTexture.name);
+
                 // Write bitmap
                 if (isBabylonExported)
                 {

--- a/SharedProjects/Utilities/PathUtilities.cs
+++ b/SharedProjects/Utilities/PathUtilities.cs
@@ -57,5 +57,16 @@ namespace Utilities
 
             return path;
         }
+
+        public static string VerifyLegalFileName(string fileName)
+        {
+            // Checks a filename for illegal characters, spaces, and # signs and replaces with an underscore ("_")
+            string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars()) + " #";
+            Regex r = new Regex(string.Format("[{0}]", Regex.Escape(regexSearch)));
+            return r.Replace(fileName, "_");
+            //source: https://stackoverflow.com/a/146162/301388
+        }
     }
+
+
 }


### PR DESCRIPTION
…th the exporter webserver when trying to view the exported Babylon files . Added a function to remove any illegal or troublesome characters in texture generated files and replace with an underscore.

First noticed this when using  a material with non-default opaqueness settings. After the exporter made the scene I would get a 404 on the mat file in question. Noticed it was bringing over the '#' and that the built in webserver didnt care for that. 