### PR TITLE
Fix substring comparison between full path of Maya joint and joint name

### DIFF
--- a/Maya/Exporter/BabylonExporter.Skeleton.cs
+++ b/Maya/Exporter/BabylonExporter.Skeleton.cs
@@ -113,7 +113,8 @@ namespace Maya2Babylon
             for(int index = 0; index < mayaInfluenceNames.Count; index++)
             {
                 string name = mayaInfluenceNames[index];
-                int indexFullPathName = boneFullPathNames.FindIndex(fullPathName => fullPathName.EndsWith(name));
+                string name_substring = "|" + name;
+                int indexFullPathName = boneFullPathNames.FindIndex(fullPathName => fullPathName.EndsWith(name_substring));
                 mayaInfluenceNames[index] = boneFullPathNames[indexFullPathName];
 
                 if (index == 0) {


### PR DESCRIPTION
Case that brought this up: comparing a joint named "head" to the full path of a joint named "forehead"