### PR TITLE
fix bug: extra "metallicRoughnessTexture"

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
@@ -248,8 +248,8 @@ namespace Babylon2GLTF
                         string baseColorBitmapName = null;
                         string metallicRoughnessBitmapName = null;
 
-                        GLTFTextureInfo textureInfoBC = new GLTFTextureInfo();
-                        GLTFTextureInfo textureInfoMR = new GLTFTextureInfo();
+                        GLTFTextureInfo textureInfoBC = null;
+                        GLTFTextureInfo textureInfoMR = null;
 
                         if (exportParameters.writeTextures)
                         {


### PR DESCRIPTION
When i exported several model with textures to one gltf model, the gltf model has a wrong material which has an extra `metallicRoughnessTexture` attribute, but i didn't add any specular textures. The gltf model as follow:
```json
  "materials": [
    {
      "pbrMetallicRoughness": {
        "baseColorTexture": {
          "index": 0
        },
        "metallicFactor": 0,
        "roughnessFactor": 0.450053632
      },
      "name": "01 - Default"
    },
    {
      "pbrMetallicRoughness": {
        "baseColorTexture": {
          "index": 1
        },
        "metallicFactor": 0,
        "roughnessFactor": 0.450053632
      },
      "name": "02 - Default"
    },
    {
      "pbrMetallicRoughness": {
        "baseColorTexture": {
          "index": 1
        },
        "metallicRoughnessTexture": {
          "index": 0
        }
      },
      "name": "03 - Default"
    }
  ],
```
The `03 - Default` material should be same with `02 - Default`.

I know the `optimizer` is used to merge materials with same textures, but if `textureInfoMR` has a initial value, and then `AddStandText` will add a `textureInfoMR` with `index=0` even if there is no textureInfoMR actually. And then if the next material can merge with the previous material, the wrong `_pairBCMR.metallicRoughness` with `index=0` will assigned to `metallicRoughnessTexture`:
```
gltfPbrMetallicRoughness.metallicRoughnessTexture = _pairBCMR.metallicRoughness;
```
So i think this is the reason for extra "metallicRoughnessTexture".