### PR TITLE
Export morph target names to GLTF

### DIFF
--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -1255,11 +1255,15 @@ namespace Maya2Babylon
                 MIntArray weightIndexList = new MIntArray();    // list of weight. For each weight, there are multiple targets
                 blendShapeDeformer.weightIndexList(weightIndexList);
 
+                MPlug plugWeight = blendShapeDeformer.findPlug("weight");
 
                 for (int i = 0; i < weightIndexList.Count; i++)
                 {
                     int weightIndex = weightIndexList[i];
                     float weight = blendShapeDeformer.weight((uint)weightIndex);
+
+                    MPlug plugCurrentWeight = plugWeight.elementByLogicalIndex((uint)weightIndex);
+                    string currentWeightName = blendShapeDeformer.plugsAlias(plugCurrentWeight);
 
                     MObjectArray targets = new MObjectArray();  // the targets for the given weight
                     blendShapeDeformer.getTargets(baseObject, weightIndex, targets);
@@ -1271,7 +1275,7 @@ namespace Maya2Babylon
 
                         BabylonMorphTarget babylonMorphTarget = new BabylonMorphTarget
                         {
-                            name = $"{blendShapeDeformer.name}_{targetMesh.name}",
+                            name = $"{blendShapeDeformer.name}.{currentWeightName}",
                             influence = envelope * weight,
                             id = Guid.NewGuid().ToString()
                         };

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -408,15 +408,22 @@ namespace Babylon2GLTF
             }
             gltfMesh.primitives = meshPrimitives.ToArray();
 
-            // Morph targets weights
+            // Morph targets weights and names
             if (babylonMorphTargetManager != null)
             {
                 var weights = new List<float>();
+                var targetNames = new List<String>();
                 foreach (BabylonMorphTarget babylonMorphTarget in babylonMorphTargetManager.targets)
                 {
                     weights.Add(babylonMorphTarget.influence);
+                    targetNames.Add(babylonMorphTarget.name);
                 }
                 gltfMesh.weights = weights.ToArray();
+
+                if (gltfMesh.extras == null) {
+                    gltfMesh.extras = new Dictionary<string, object>();
+                }
+                gltfMesh.extras["targetNames"] = targetNames.ToArray();
             }
 
             if (hasBones)


### PR DESCRIPTION
Add mesh.extras.targetNames to gltf export.
Use "{blendShapeDeformer.name}.{currentWeightName}" as the name for babylonMorphTarget.