### PR TITLE
Floating point precision to Babylon

### DIFF
--- a/Maya/Exporter/BabylonExporter.Writer.cs
+++ b/Maya/Exporter/BabylonExporter.Writer.cs
@@ -1,9 +1,12 @@
 using BabylonExport.Entities;
 using BabylonFileConverter;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using Utilities;
 
 namespace Maya2Babylon
 {
@@ -21,7 +24,11 @@ namespace Maya2Babylon
                 
             using (var jsonWriter = new JsonTextWriterOptimized(sw))
             {
+#if DEBUG
+                jsonWriter.Formatting = Formatting.Indented;
+#else
                 jsonWriter.Formatting = Formatting.None;
+#endif
                 jsonSerializer.Serialize(jsonWriter, babylonScene);
             }
             File.WriteAllText(outputFile, sb.ToString());

--- a/Maya/Maya2Babylon2020.csproj
+++ b/Maya/Maya2Babylon2020.csproj
@@ -123,8 +123,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Tools\JsonTextWriterBounded.cs" />
-    <Compile Include="Tools\JsonTextWriterOptimized.cs" />
     <Compile Include="Tools\Tools.cs" />
     <Compile Include="Tools\WebServer.cs" />
   </ItemGroup>

--- a/SharedProjects/Utilities/JsonTextWriterOptimized.cs
+++ b/SharedProjects/Utilities/JsonTextWriterOptimized.cs
@@ -6,13 +6,19 @@ namespace Utilities
 {
     class JsonTextWriterOptimized : JsonTextWriter
     {
-        public JsonTextWriterOptimized(TextWriter textWriter)
+        internal const int DefaultNumberOfDigit = 8;
+
+        int _d;
+
+        public JsonTextWriterOptimized(TextWriter textWriter, int numberOfDigit = DefaultNumberOfDigit)
             : base(textWriter)
         {
+            _d = numberOfDigit;
         }
+
         public override void WriteValue(float value)
         {
-            value = (float)Math.Round(value, 4);
+            value = (float)Math.Round(value, _d);
             base.WriteValue(value);
         }
     }


### PR DESCRIPTION
Change the default json number precision from 4 to 8 to babylon file. fix #895, fix #869 
Clear unused/duplicated code into Maya/Exporter