### PR TITLE
Fix Animation Group

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -112,7 +112,7 @@ namespace Max2Babylon
         public void FlattenItem(ref IINode itemNode)
         {
             AnimationGroupList animationGroupList = new AnimationGroupList();
-            animationGroupList.LoadFromData(Loader.Core.RootNode);
+            animationGroupList.LoadFromData(this,Loader.Core.RootNode);
 
             if (itemNode == null)
             {


### PR DESCRIPTION
Init the serialized ID of AnimationGroup when loading from properties. The bad initialization of the SerializedID prevent the MaxScript to work. This is related to this [question](https://forum.babylonjs.com/t/how-to-use-maxscript-to-add-animation-group-nodes/16836) from the forum.