### PR TITLE
Use project default light property

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -550,7 +550,7 @@ namespace Max2Babylon
             // Default light
             if (exportParameters.exportAnimationsOnly == false)
             {
-                if (!exportParameters.pbrNoLight && babylonScene.LightsList.Count == 0)
+                if (!exportParameters.pbrNoLight && babylonScene.LightsList.Count == 0 && rawScene.GetBoolProperty("babylonjs_addDefaultLight"))
                 {
                     RaiseWarning("No light defined", 1);
                     RaiseWarning("A default hemispheric light was added for your convenience", 1);


### PR DESCRIPTION
Max2Babylon added an empty node called “Default light”, even though the Babylon Scene Properties has the default light disabled 