### PR TITLE
Add support for MaterialId on multiMaterial

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -808,12 +808,15 @@ namespace Max2Babylon
             int indexInFaceIndexesArray = 0;
             for (int i = 0; i < multiMatsCount; ++i)
             {
-                int materialId = i;
                 var indexCount = 0;
                 var minVertexIndex = int.MaxValue;
                 var maxVertexIndex = int.MinValue;
+                // Material Id is 0 if normal material, and GetMaterialID if multi-material
+                // default is [1,n] increment by 1 but user can decide to change the id (still an int) and set for example [4,3,9,1]
+                // note that GetMaterialID return the user id minus 1
+                int materialId = multiMatsCount == 1? i : meshNode.NodeMaterial.GetMaterialID(i);
                 var subMesh = new BabylonSubMesh { indexStart = indexStart, materialIndex = i };
-
+ 
                 if (multiMatsCount == 1)
                 {
                     for (int j = 0; j < unskinnedMesh.NumberOfFaces; ++j)
@@ -898,10 +901,9 @@ namespace Max2Babylon
                         }
                     }
                 }
-
+ 
                 if (indexCount != 0)
                 {
-
                     subMesh.indexCount = indexCount;
                     subMesh.verticesStart = minVertexIndex;
                     subMesh.verticesCount = maxVertexIndex - minVertexIndex + 1;

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -901,7 +901,6 @@ namespace Max2Babylon
                         }
                     }
                 }
- 
                 if (indexCount != 0)
                 {
                     subMesh.indexCount = indexCount;

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -816,7 +816,6 @@ namespace Max2Babylon
                 // note that GetMaterialID return the user id minus 1
                 int materialId = multiMatsCount == 1? i : meshNode.NodeMaterial.GetMaterialID(i);
                 var subMesh = new BabylonSubMesh { indexStart = indexStart, materialIndex = i };
- 
                 if (multiMatsCount == 1)
                 {
                     for (int j = 0; j < unskinnedMesh.NumberOfFaces; ++j)


### PR DESCRIPTION
On Multi-Material, when user set it's own id, we must access the id using Max meshNode.NodeMaterial.GetMaterialID(i) instead of assign sequential index Fix #926 