### PR TITLE
3DSMax Test BaseColorTexture for null

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -344,7 +344,7 @@ namespace Max2Babylon
                 return null;
             }
 
-            var baseColorSourcePath = baseColorTexture.Map.FullFilePath;
+            var baseColorSourcePath = baseColorTexture?.Map.FullFilePath;
             var alphaSourcePath = alphaTexture?.Map.FullFilePath;
 
             // If we only have a base color texture, and we are using an opaque texture, export the base color image only.


### PR DESCRIPTION
When base color texture is null, add check to avoid exception and prevent exporter to stop.
This is related to [this ](https://forum.babylonjs.com/t/3dsmax-exporter-error-while-using-transparency-map/18854/3) forum discussion