### PR TITLE
Null Tangent check

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -419,7 +419,10 @@ namespace Max2Babylon
                 // Export tangents if option is checked and mesh has tangents
                 if (exportParameters.exportTangents)
                 {
-                    babylonMesh.tangents = vertices.SelectMany(v => v.Tangent).ToArray();
+                    if (vertices.All(v => v.Tangent != null))
+                    {
+                        babylonMesh.tangents = vertices.SelectMany(v => v.Tangent).ToArray();
+                    }
                 }
 
                 if (hasUV)


### PR DESCRIPTION
When any of object tangents are null and "use tangent" check box has been set, this was result into Object Null Exception. Fix #951 