### PR TITLE
Add max bump properties to 3dsMax

### DIFF
--- a/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
+++ b/3ds Max/Max2Babylon/2015/Max2Babylon2015.csproj
@@ -336,6 +336,9 @@
   <ItemGroup>
     <Content Include="Refs\Autodesk.Max.dll" />
     <Content Include="Refs\ManagedServices.dll" />
+    <None Include="..\Scripts\BUMP_MAP_CAT_DEF.ms">
+      <Link>Scripts\BUMP_MAP_CAT_DEF.ms</Link>
+    </None>
     <None Include="Resources\MaxExporter.png" />
   </ItemGroup>
   <ItemGroup>

--- a/3ds Max/Max2Babylon/2015/Properties/Resources.Designer.cs
+++ b/3ds Max/Max2Babylon/2015/Properties/Resources.Designer.cs
@@ -71,6 +71,16 @@ namespace Max2Babylon.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] BUMP_MAP_CAT_DEF {
+            get {
+                object obj = ResourceManager.GetObject("BUMP_MAP_CAT_DEF", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap MaxExporter {

--- a/3ds Max/Max2Babylon/2015/Properties/Resources.resx
+++ b/3ds Max/Max2Babylon/2015/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARNOLD_MATERIAL_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="BUMP_MAP_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Scripts\BUMP_MAP_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="MaxExporter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MaxExporter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
+++ b/3ds Max/Max2Babylon/2017/Max2Babylon2017.csproj
@@ -337,6 +337,9 @@
   <ItemGroup>
     <Content Include="Refs\Autodesk.Max.dll" />
     <Content Include="Refs\ManagedServices.dll" />
+    <None Include="..\Scripts\BUMP_MAP_CAT_DEF.ms">
+      <Link>Scripts\BUMP_MAP_CAT_DEF.ms</Link>
+    </None>
     <None Include="Resources\MaxExporter.png" />
   </ItemGroup>
   <ItemGroup>

--- a/3ds Max/Max2Babylon/2017/Properties/Resources.Designer.cs
+++ b/3ds Max/Max2Babylon/2017/Properties/Resources.Designer.cs
@@ -71,6 +71,16 @@ namespace Max2Babylon.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] BUMP_MAP_CAT_DEF {
+            get {
+                object obj = ResourceManager.GetObject("BUMP_MAP_CAT_DEF", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap MaxExporter {

--- a/3ds Max/Max2Babylon/2017/Properties/Resources.resx
+++ b/3ds Max/Max2Babylon/2017/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARNOLD_MATERIAL_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="BUMP_MAP_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Scripts\BUMP_MAP_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="MaxExporter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MaxExporter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
+++ b/3ds Max/Max2Babylon/2018/Max2Babylon2018.csproj
@@ -390,6 +390,9 @@
     <None Include="..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\ARNOLD_MATERIAL_CAT_DEF.ms</Link>
     </None>
+    <None Include="..\Scripts\BUMP_MAP_CAT_DEF.ms">
+      <Link>Scripts\BUMP_MAP_CAT_DEF.ms</Link>
+    </None>
     <None Include="..\Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms</Link>
     </None>

--- a/3ds Max/Max2Babylon/2018/Properties/Resources.Designer.cs
+++ b/3ds Max/Max2Babylon/2018/Properties/Resources.Designer.cs
@@ -71,6 +71,16 @@ namespace Max2Babylon.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] BUMP_MAP_CAT_DEF {
+            get {
+                object obj = ResourceManager.GetObject("BUMP_MAP_CAT_DEF", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap MaxExporter {

--- a/3ds Max/Max2Babylon/2018/Properties/Resources.resx
+++ b/3ds Max/Max2Babylon/2018/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARNOLD_MATERIAL_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="BUMP_MAP_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Scripts\BUMP_MAP_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="MaxExporter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MaxExporter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/3ds Max/Max2Babylon/2019/Max2Babylon2019.csproj
+++ b/3ds Max/Max2Babylon/2019/Max2Babylon2019.csproj
@@ -394,6 +394,9 @@
     <None Include="..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\ARNOLD_MATERIAL_CAT_DEF.ms</Link>
     </None>
+    <None Include="..\Scripts\BUMP_MAP_CAT_DEF.ms">
+      <Link>Scripts\BUMP_MAP_CAT_DEF.ms</Link>
+    </None>
     <None Include="..\Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms</Link>
     </None>

--- a/3ds Max/Max2Babylon/2019/Properties/Resources.Designer.cs
+++ b/3ds Max/Max2Babylon/2019/Properties/Resources.Designer.cs
@@ -71,6 +71,16 @@ namespace Max2Babylon.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] BUMP_MAP_CAT_DEF {
+            get {
+                object obj = ResourceManager.GetObject("BUMP_MAP_CAT_DEF", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap MaxExporter {

--- a/3ds Max/Max2Babylon/2019/Properties/Resources.resx
+++ b/3ds Max/Max2Babylon/2019/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARNOLD_MATERIAL_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="BUMP_MAP_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Scripts\BUMP_MAP_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="MaxExporter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MaxExporter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/3ds Max/Max2Babylon/2020/Max2Babylon2020.csproj
+++ b/3ds Max/Max2Babylon/2020/Max2Babylon2020.csproj
@@ -394,6 +394,9 @@
     <None Include="..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\ARNOLD_MATERIAL_CAT_DEF.ms</Link>
     </None>
+    <None Include="..\Scripts\BUMP_MAP_CAT_DEF.ms">
+      <Link>Scripts\BUMP_MAP_CAT_DEF.ms</Link>
+    </None>
     <None Include="..\Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms</Link>
     </None>

--- a/3ds Max/Max2Babylon/2020/Properties/Resources.Designer.cs
+++ b/3ds Max/Max2Babylon/2020/Properties/Resources.Designer.cs
@@ -71,6 +71,16 @@ namespace Max2Babylon.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] BUMP_MAP_CAT_DEF {
+            get {
+                object obj = ResourceManager.GetObject("BUMP_MAP_CAT_DEF", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap MaxExporter {

--- a/3ds Max/Max2Babylon/2020/Properties/Resources.resx
+++ b/3ds Max/Max2Babylon/2020/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARNOLD_MATERIAL_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="BUMP_MAP_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Scripts\BUMP_MAP_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="MaxExporter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MaxExporter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/3ds Max/Max2Babylon/2021/Max2Babylon2021.csproj
+++ b/3ds Max/Max2Babylon/2021/Max2Babylon2021.csproj
@@ -394,6 +394,9 @@
     <None Include="..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\ARNOLD_MATERIAL_CAT_DEF.ms</Link>
     </None>
+    <None Include="..\Scripts\BUMP_MAP_CAT_DEF.ms">
+      <Link>Scripts\BUMP_MAP_CAT_DEF.ms</Link>
+    </None>
     <None Include="..\Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms">
       <Link>Scripts\PHYSICAL_MATERIAL_CAT_DEF.ms</Link>
     </None>

--- a/3ds Max/Max2Babylon/2021/Properties/Resources.Designer.cs
+++ b/3ds Max/Max2Babylon/2021/Properties/Resources.Designer.cs
@@ -71,6 +71,16 @@ namespace Max2Babylon.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] BUMP_MAP_CAT_DEF {
+            get {
+                object obj = ResourceManager.GetObject("BUMP_MAP_CAT_DEF", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap MaxExporter {

--- a/3ds Max/Max2Babylon/2021/Properties/Resources.resx
+++ b/3ds Max/Max2Babylon/2021/Properties/Resources.resx
@@ -121,6 +121,9 @@
   <data name="ARNOLD_MATERIAL_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\Scripts\ARNOLD_MATERIAL_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="BUMP_MAP_CAT_DEF" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Scripts\BUMP_MAP_CAT_DEF.ms;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="MaxExporter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\MaxExporter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/3ds Max/Max2Babylon/GlobalUtility.cs
+++ b/3ds Max/Max2Babylon/GlobalUtility.cs
@@ -349,6 +349,9 @@ namespace Max2Babylon
             Loader.Global.COREInterface.MenuManager.UpdateMenuBar();
         }
 
-        private void AddCallbacks() => ManagedServices.MaxscriptSDK.ExecuteMaxscriptCommand(MaterialScripts.AddCallback);
+        private void AddCallbacks() 
+        {
+            foreach (var s in MaterialScripts.AddCallbacks()) ManagedServices.MaxscriptSDK.ExecuteMaxscriptCommand(s);
+        }
     }
 }

--- a/3ds Max/Max2Babylon/MaterialScripts.cs
+++ b/3ds Max/Max2Babylon/MaterialScripts.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text;
 
 namespace Max2Babylon
@@ -13,19 +14,59 @@ namespace Max2Babylon
         public static string StandardBabylonCAtDef => Encoding.UTF8.GetString(Properties.Resources.STANDARD_MATERIAL_CAT_DEF);
         public static string AIBabylonCAtDef => Encoding.UTF8.GetString(Properties.Resources.ARNOLD_MATERIAL_CAT_DEF);
         public static string PhysicalBabylonCAtDef => Encoding.UTF8.GetString(Properties.Resources.PHYSICAL_MATERIAL_CAT_DEF);
+        public static string BumpMapCAtDef => Encoding.UTF8.GetString(Properties.Resources.BUMP_MAP_CAT_DEF);
+
+        public static string HasBabylonAttribute => @"fn hasBabylonCustomAttribute mat attName = ( 
+          l = custAttributes.count mat; 
+          for i = 1 to l+1 do ( 
+            if(mat.custAttributes[i] != undefined) then (
+                if(mat.custAttributes[i].name == attName) then return true
+            ) ) return false )";
+
+        /// <summary>
+        /// Note : We may run a check on all Slate view, because race condition into script execution 
+        /// do not ensure the link beetwen material and bump are correctly set when material is updated.
+        /// </summary>
+        public static string CheckBumpMap = $@"fn checkBumpMap = (
+			local babylonAttName = ""Babylon Attributes""
+			for v=1 to sme.GetNumViews() do 
+			(
+				viewNode = sme.GetView(v)
+				for i=1 to viewNode.GetNumNodes() do
+				(
+					n = viewNode.GetNode i;
+					if(classof n.reference == Normal_Bump ) then
+				    (
+					   nbump = n.reference
+					   if(hasBabylonCustomAttribute nbump babylonAttName == false ) then
+					   (
+                            {BumpMapCAtDef}
+							custAttributes.add nbump BUMP_MAP_CAT_DEF
+					   )
+					) 
+				)	
+			)        
+        )";
+
+        /// There is NO WAY to get an even on BumpMap creation into the Slate editor. Only Material creation is triggered.
+        /// This is the reason we listen for parameters Material change
+        private static string AddPhysicalBabylonUI =
+        $@"if ( hasBabylonCustomAttribute maxMaterial ""Babylon Attributes"" == false) then ( 
+              {PhysicalBabylonCAtDef}
+              custAttributes.add maxMaterial PHYSICAL_MATERIAL_CAT_DEF 
+              when parameters maxMaterial change do checkBumpMap()
+        )";
+
         public static string AddCallback => $@"addMaterialCallbackScript = ""maxMaterial = callbacks.notificationParam();
         if classof maxMaterial == StandardMaterial then (
             {StandardBabylonCAtDef.AsInlineScript()} 
             custAttributes.add maxMaterial STANDARD_MATERIAL_CAT_DEF;
         ) else  if classof maxMaterial == PhysicalMaterial then (
-            {PhysicalBabylonCAtDef.AsInlineScript()}
-            custAttributes.add maxMaterial PHYSICAL_MATERIAL_CAT_DEF;
+            {AddPhysicalBabylonUI.AsInlineScript()}
         ) else  if classof maxMaterial == PBRMetalRough then (
-            {PhysicalBabylonCAtDef.AsInlineScript()}
-            custAttributes.add maxMaterial PHYSICAL_MATERIAL_CAT_DEF;
+            {AddPhysicalBabylonUI.AsInlineScript()}
         ) else  if classof maxMaterial == PBRSpecGloss then (
-            {PhysicalBabylonCAtDef.AsInlineScript()}
-            custAttributes.add maxMaterial PHYSICAL_MATERIAL_CAT_DEF;
+            {AddPhysicalBabylonUI.AsInlineScript()}
         ) else if classof maxMaterial == ai_standard_surface then (
             {AIBabylonCAtDef.AsInlineScript()}
             custAttributes.add maxMaterial babylonAttributesDataCA;
@@ -39,5 +80,12 @@ namespace Max2Babylon
         -- This means that it is not linked to a specific file.
         -- Rather, the callback is active for the current run of 3ds Max.
         callbacks.addScript #mtlRefAdded addMaterialCallbackScript id:#BabylonAttributesMaterial;";
+
+        public static IEnumerable<string> AddCallbacks()
+        {
+            yield return HasBabylonAttribute;
+            yield return CheckBumpMap;
+            yield return AddCallback;
+        }
     } 
 }

--- a/3ds Max/Max2Babylon/Scripts/BUMP_MAP_CAT_DEF.ms
+++ b/3ds Max/Max2Babylon/Scripts/BUMP_MAP_CAT_DEF.ms
@@ -1,0 +1,44 @@
+-- A script material utilities for Babylon Exporter
+-- Modified: 2021-03-22
+-- Copyright 2021 Microsoft, All rights reserved. This file is licensed under Apache 2.0 license
+
+-- Bump Map custom attribute definition
+BUMP_MAP_CAT_DEF = attributes "Babylon Attributes" attribID:#(0x4f890716, 0x24da1760)
+version:2
+(
+    parameters main rollout:params
+    (
+        babylonUseMaxTransforms type:#boolean ui:babylonUseMaxTransforms_ui default:false
+        --Normal direction : Y+ or Y-, Y+ is OpenGL, Y- is Directx
+        babylonNMY type:#integer ui:babylonBumpFormat_ui default:0
+        --Coordinate system : Right or Left. OpenGL is Right Handed when DirectX is Left handed
+        babylonNMCoordinate type:#integer ui:babylonBumpFormat_ui default:0
+    )
+    rollout params "Babylon Attributes"
+    (
+        checkbox babylonUseMaxTransforms_ui "Use 3dsMax Channel directions"
+        group "Normal Map Setting" (
+            radiobuttons  babylonNMY labels:#("Unknown","Y+", "Y-") 
+            radiobuttons  babylonNMCoordinate labels:#("Unknown","Right", "Left") 
+            --instead of declaring the whole input format. We can add a bunch of button for preset values such DirectX, OpenGL, Clear
+            button SetDirectXBtn "DirectX"
+            button SetOpenGlBtn  "OpenGL"
+            button ClearBtn "Clear"
+        )
+        on ClearBtn pressed do
+        (
+            babylonNMY = 0
+            babylonNMCoordinate = 0
+        )
+        on SetOpenGlBtn pressed do
+        (
+            babylonNMY = 1
+            babylonNMCoordinate = 1
+        )
+        on SetDirectXBtn pressed do 
+        (
+            babylonNMY = 2
+            babylonNMCoordinate = 2
+        )
+    )    
+)

--- a/3ds Max/Max2Babylon/Scripts/BUMP_MAP_CAT_DEF.ms
+++ b/3ds Max/Max2Babylon/Scripts/BUMP_MAP_CAT_DEF.ms
@@ -3,42 +3,50 @@
 -- Copyright 2021 Microsoft, All rights reserved. This file is licensed under Apache 2.0 license
 
 -- Bump Map custom attribute definition
-BUMP_MAP_CAT_DEF = attributes "Babylon Attributes" attribID:#(0x4f890716, 0x24da1760)
-version:2
+BUMP_MAP_CAT_DEF = attributes "Babylon Attributes" attribID:#(0x4f890984, 0x24da8888)
+version:1
 (
+    local description = "Help Export with the definition of the normal map format"
     parameters main rollout:params
     (
         babylonUseMaxTransforms type:#boolean ui:babylonUseMaxTransforms_ui default:false
         --Normal direction : Y+ or Y-, Y+ is OpenGL, Y- is Directx
-        babylonNMY type:#integer ui:babylonBumpFormat_ui default:0
+        babylonNMY type:#integer ui:babylonNMY_ui default:1
         --Coordinate system : Right or Left. OpenGL is Right Handed when DirectX is Left handed
-        babylonNMCoordinate type:#integer ui:babylonBumpFormat_ui default:0
+        babylonNMCoordinate type:#integer ui:babylonNMCoordinate_ui default:1
     )
     rollout params "Babylon Attributes"
     (
-        checkbox babylonUseMaxTransforms_ui "Use 3dsMax Channel directions"
-        group "Normal Map Setting" (
-            radiobuttons  babylonNMY labels:#("Unknown","Y+", "Y-") 
-            radiobuttons  babylonNMCoordinate labels:#("Unknown","Right", "Left") 
-            --instead of declaring the whole input format. We can add a bunch of button for preset values such DirectX, OpenGL, Clear
-            button SetDirectXBtn "DirectX"
-            button SetOpenGlBtn  "OpenGL"
-            button ClearBtn "Clear"
+        edittext lvl readOnly:true text:description height:20
+        checkbox babylonUseMaxTransforms_ui "Use 3dsMax Channel Direction"
+        group "Normal Map Y" (
+           radiobuttons  babylonNMY_ui labels:#("Unknown","Y+", "Y-") 
+        ) 
+        group "Normal Map Coordinate" (
+           radiobuttons  babylonNMCoordinate_ui labels:#("Unknown","Right", "Left")
         )
+           
+        --instead of declaring the whole input format. We can add a bunch of button for preset values such DirectX, OpenGL, Clear
+        group "Preset" (
+           button SetDirectXBtn "DirectX" across:3
+           button SetOpenGlBtn  "OpenGL"
+           button ClearBtn "Clear"
+        )
+        
         on ClearBtn pressed do
-        (
-            babylonNMY = 0
-            babylonNMCoordinate = 0
-        )
-        on SetOpenGlBtn pressed do
         (
             babylonNMY = 1
             babylonNMCoordinate = 1
         )
-        on SetDirectXBtn pressed do 
+        on SetOpenGlBtn pressed do
         (
             babylonNMY = 2
             babylonNMCoordinate = 2
+        )
+        on SetDirectXBtn pressed do 
+        (
+            babylonNMY = 3
+            babylonNMCoordinate = 3
         )
     )    
 )


### PR DESCRIPTION
 3DSMAX : Add support for Babylon custom attributes for Normal Map. This prepare the ability to process the normal map according Babylon AND GLTF specification. Resolve #940
![image](https://user-images.githubusercontent.com/22658224/117531372-7ed09280-afe2-11eb-8b2d-926bf0b35f6f.png)
