### PR TITLE
3dsMax : Add keep position option to multi export process.

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.ExportItem.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.ExportItem.cs
@@ -102,11 +102,20 @@ namespace Max2Babylon
                 IsDirty = true;
             }
         }
+        public bool KeepPosition
+        {
+            get { return keepPosition; }
+            set
+            {
+                if (keepPosition == value) return;
+                keepPosition = value;
+                IsDirty = true;
+            }
+        }
 
-        const string s_DisplayNameFormat = "{0} | {1} | \"{2}\" | \"{3}\"| {4}";
-        const char s_PropertySeparator = ';';
+         const char s_PropertySeparator = ';';
         private const char s_ProperyLayerSeparator = '~';
-        const string s_PropertyFormat = "{0};{1};{2};{3}";
+        const string s_PropertyFormat = "{0};{1};{2};{3};{4}";
         const string s_PropertyNamePrefix = "babylonjs_ExportItem";
 
         private string outputFileExt;
@@ -114,6 +123,7 @@ namespace Max2Babylon
         private List<IILayer> exportLayers;
         private uint exportNodeHandle = uint.MaxValue; // 0 is the scene root node
         private bool selected = true;
+        private bool keepPosition = false;
         private string exportPathRelative = "";
         private string exportPathAbsolute = "";
         private string exportTexturesFolderRelative = "";
@@ -154,7 +164,7 @@ namespace Max2Babylon
             LoadFromData(propertyName);
         }
 
-        public override string ToString() { return string.Format(s_DisplayNameFormat, selected, NodeName, exportPathRelative, exportTexturesFolderRelative, LayersToString(exportLayers)); }
+        public override string ToString() { return $"{selected} | {keepPosition} | { NodeName} | \"{exportPathRelative}\" | \"{ exportTexturesFolderRelative}\" | { LayersToString(exportLayers)}"; }
 
         public void SetExportLayers(List<IILayer> layers)
         {
@@ -303,21 +313,21 @@ namespace Max2Babylon
             if (properties.Length < 2)
                 throw new Exception("Invalid number of properties, can't deserialize.");
 
-
-            if (!bool.TryParse(properties[0], out selected))
+            var i = 0;
+            if (!bool.TryParse(properties[i++], out selected))
+                throw new Exception(string.Format("Failed to parse selected property from string {0}", properties[0]));
+            
+            if (!bool.TryParse(properties[i++], out keepPosition))
                 throw new Exception(string.Format("Failed to parse selected property from string {0}", properties[0]));
 
-            
-            SetExportFilePath(properties[1]);
-            SetExportTexturesFolderPath(properties[2]);
-            List<IILayer> layers = StringToLayers(properties[3]);
+            SetExportFilePath(properties[i++]);
+            SetExportTexturesFolderPath(properties[i++]);
+            List<IILayer> layers = StringToLayers(properties[i++]);
+
             if (layers.Count > 0)
             {
                 SetExportLayers(layers);
             }
-
-            
-
             IsDirty = false;
         }
 
@@ -333,7 +343,7 @@ namespace Max2Babylon
             IINode node = Node;
             if (node == null) return false;
 
-            node.SetStringProperty(GetPropertyName(), string.Format(s_PropertyFormat, selected.ToString(), exportPathRelative,exportTexturesFolderRelative,LayersToString(exportLayers)));
+            node.SetStringProperty(GetPropertyName(), string.Format(s_PropertyFormat, selected.ToString(), keepPosition.ToString(), exportPathRelative,exportTexturesFolderRelative,LayersToString(exportLayers)));
 
             IsDirty = false;
             return true;

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.ExportItem.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.ExportItem.cs
@@ -314,15 +314,15 @@ namespace Max2Babylon
                 throw new Exception("Invalid number of properties, can't deserialize.");
 
             var i = 0;
-            if (!bool.TryParse(properties[i++], out selected))
-                throw new Exception(string.Format("Failed to parse selected property from string {0}", properties[0]));
+            if (!bool.TryParse(properties[i], out selected))
+                throw new Exception(string.Format("Failed to parse selected property from string {0}", properties[i]));
             
-            if (!bool.TryParse(properties[i++], out keepPosition))
-                throw new Exception(string.Format("Failed to parse selected property from string {0}", properties[0]));
+            if (!bool.TryParse(properties[++i], out keepPosition))
+                throw new Exception(string.Format("Failed to parse selected property from string {0}", properties[i]));
 
-            SetExportFilePath(properties[i++]);
-            SetExportTexturesFolderPath(properties[i++]);
-            List<IILayer> layers = StringToLayers(properties[i++]);
+            SetExportFilePath(properties[++i]);
+            SetExportTexturesFolderPath(properties[++i]);
+            List<IILayer> layers = StringToLayers(properties[++i]);
 
             if (layers.Count > 0)
             {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -839,7 +839,6 @@ namespace Max2Babylon
                 babylonInstanceMesh.physicsRestitution = maxNode.MaxNode.GetFloatProperty("babylonjs_restitution", 0.2f);
             }
 
-
             // Add instance to master mesh
             List<BabylonAbstractMesh> list = babylonMasterMesh.instances != null ? babylonMasterMesh.instances.ToList() : new List<BabylonAbstractMesh>();
             list.Add(babylonInstanceMesh);

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -476,7 +476,12 @@ namespace Max2Babylon
                 BabylonNode node = exportNodeRec(maxRootNode, babylonScene, gameScene);
                 // if we're exporting from a specific node, reset the pivot to {0,0,0}
                 if (node != null && exportNode != null && !exportNode.IsRootNode)
-                    SetNodePosition(ref node, ref babylonScene, new float[] { 0, 0, 0 });
+                {
+                    if (!exportParameters.exportKeepNodePosition)
+                    {
+                        SetNodePosition(ref node, ref babylonScene, new float[] { 0, 0, 0 });
+                    }
+                }
 
                 progression += progressionStep;
                 ReportProgressChanged((int)progression);

--- a/3ds Max/Max2Babylon/Exporter/MaxExportParameters.cs
+++ b/3ds Max/Max2Babylon/Exporter/MaxExportParameters.cs
@@ -15,6 +15,7 @@ namespace Max2Babylon
     {
         public Autodesk.Max.IINode exportNode;
         public List<Autodesk.Max.IILayer> exportLayers;
+        public bool exportKeepNodePosition = false;
         public bool usePreExportProcess = false;
         public bool applyPreprocessToScene = false;
         public bool mergeContainersAndXRef = false;

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -488,6 +488,7 @@ namespace Max2Babylon
                     optimizeAnimations = !chkDoNotOptimizeAnimations.Checked,
                     animgroupExportNonAnimated = chkAnimgroupExportNonAnimated.Checked,
                     exportNode = exportItem?.Node,
+                    exportKeepNodePosition = exportItem?.KeepPosition??false,
                     exportLayers = exportItem?.Layers,
                     pbrNoLight = chkNoAutoLight.Checked,
                     pbrFull = chkFullPBR.Checked,

--- a/3ds Max/Max2Babylon/Forms/MultiExportForm.Designer.cs
+++ b/3ds Max/Max2Babylon/Forms/MultiExportForm.Designer.cs
@@ -39,6 +39,7 @@ namespace Max2Babylon
             this.panel1 = new System.Windows.Forms.Panel();
             this.ExportItemGridView = new System.Windows.Forms.DataGridView();
             this.ColumnExportCheckbox = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.ColumnKeepPositionCheckbox = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ColumnLayers = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnNode = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -182,6 +183,7 @@ namespace Max2Babylon
             this.ExportItemGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.ExportItemGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ColumnExportCheckbox,
+            this.ColumnKeepPositionCheckbox,
             this.ColumnLayers,
             this.ColumnNode,
             this.ColumnFilePath,
@@ -206,6 +208,14 @@ namespace Max2Babylon
             this.ColumnExportCheckbox.Name = "ColumnExportCheckbox";
             this.ColumnExportCheckbox.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.ColumnExportCheckbox.Width = 49;
+            // 
+            // ColumnKeepPositionCheckbox
+            // 
+            this.ColumnKeepPositionCheckbox.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.ColumnKeepPositionCheckbox.HeaderText = "Keep Pos";
+            this.ColumnKeepPositionCheckbox.Name = "ColumnKeepPositionCheckbox";
+            this.ColumnKeepPositionCheckbox.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.ColumnKeepPositionCheckbox.Width = 49;
             // 
             // ColumnLayers
             // 
@@ -274,6 +284,7 @@ namespace Max2Babylon
         private System.Windows.Forms.SaveFileDialog SetPathFileDialog;
         private System.Windows.Forms.Button btn_change_path;
         private System.Windows.Forms.DataGridViewCheckBoxColumn ColumnExportCheckbox;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn ColumnKeepPositionCheckbox;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnLayers;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNode;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnFilePath;

--- a/3ds Max/Max2Babylon/Forms/MultiExportForm.cs
+++ b/3ds Max/Max2Babylon/Forms/MultiExportForm.cs
@@ -15,6 +15,7 @@ namespace Max2Babylon
     public partial class MultiExportForm : Form
     {
         const bool Default_ExportItemSelected = true;
+        const bool Default_KeepPosition = false;
         private CommonOpenFileDialog setTexturesFolderDialog;
         private ExportItemList exportItemList;
 
@@ -34,6 +35,7 @@ namespace Max2Babylon
             {
                 DataGridViewRow row = new DataGridViewRow();
                 row.Cells.Add(new DataGridViewCheckBoxCell());
+                row.Cells.Add(new DataGridViewCheckBoxCell());
                 row.Cells.Add(new DataGridViewTextBoxCell());
                 row.Cells.Add(new DataGridViewTextBoxCell());
                 row.Cells.Add(new DataGridViewTextBoxCell());
@@ -49,11 +51,13 @@ namespace Max2Babylon
         private void SetRowData(DataGridViewRow row, ExportItem item)
         {
             row.Tag = item;
-            row.Cells[0].Value = item.Selected;
-            row.Cells[1].Value = item.LayersToString(item.Layers);
-            row.Cells[2].Value = item.NodeName;
-            row.Cells[3].Value = item.ExportFilePathAbsolute;
-            row.Cells[4].Value = item.ExportTexturesesFolderAbsolute;
+            var i = 0;
+            row.Cells[i++].Value = item.Selected;
+            row.Cells[i++].Value = item.KeepPosition;
+            row.Cells[i++].Value = item.LayersToString(item.Layers);
+            row.Cells[i++].Value = item.NodeName;
+            row.Cells[i++].Value = item.ExportFilePathAbsolute;
+            row.Cells[i  ].Value = item.ExportTexturesesFolderAbsolute;
             Refresh();
         }
 
@@ -168,8 +172,13 @@ namespace Max2Babylon
 
             if (e.ColumnIndex == ColumnExportCheckbox.Index)
             {
-                if(item != null)
+                if (item != null)
                     item.Selected = row.Cells[0].Value == null ? Default_ExportItemSelected : (bool)row.Cells[0].Value;
+            }
+            if (e.ColumnIndex == ColumnKeepPositionCheckbox.Index)
+            {
+                if (item != null)
+                    item.KeepPosition = row.Cells[e.ColumnIndex].Value == null ? Default_KeepPosition : (bool)row.Cells[e.ColumnIndex].Value;
             }
             if (e.ColumnIndex == ColumnFilePath.Index)
             {
@@ -321,7 +330,7 @@ namespace Max2Babylon
             if (e.RowIndex < 0) return;
 
             // necessary for checkboxes, problem with datagridview
-            if (e.ColumnIndex == ColumnExportCheckbox.Index)
+            if (e.ColumnIndex == ColumnExportCheckbox.Index || e.ColumnIndex == ColumnKeepPositionCheckbox.Index)
             {
                 ExportItemGridView.EndEdit();
             }


### PR DESCRIPTION
According to #904 Introduce a new option in order to be able to do Multi-File Export without reseting the position pivot to origin. Fix #904.
![image](https://user-images.githubusercontent.com/22658224/118147395-cfdfec80-b40f-11eb-9706-9d3020fbcc41.png)
