### PR TITLE
3DSMax bump map operation support

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -83,6 +83,8 @@ namespace Max2Babylon
     /// </summary>
     partial class BabylonExporter
     {
+        const string MaterialCustomBabylonAttributeName = "Babylon Attributes";
+
         // use as scale for GetSelfIllumColor to convert [0,PI] to [O,1]
         private const float selfIllumScale = (float)(1.0 / Math.PI);
 

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -885,6 +885,10 @@ namespace Max2Babylon
 
             // try to retreive the custom Babylon Attributes
             IICustAttribContainer custAtt = texMap.CustAttribContainer;
+            if( custAtt == null)
+            {
+                yield break;
+            }
             var n = custAtt.NumCustAttribs;
             ICustAttrib att = null;
             for (int i = 0; i != n; i++)
@@ -1039,7 +1043,7 @@ namespace Max2Babylon
             }
             else
             {
-                TextureOperation[] operations = transforms.ToArray();
+                TextureOperation[] operations = transforms != null? transforms.ToArray(): new TextureOperation[]{ } ;
                 // combine transform to the destination name.
                 var operationsCodeStr = operations.Length != 0 ? $"_{operations.EncodeName()}" : string.Empty;
 

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -824,7 +824,7 @@ namespace Max2Babylon
         // -------------------------
         private ITexmap _getSpecialTexmap(ITexmap texMap, out float amount, out IEnumerable<TextureOperation> operations)
         {
-            operations = default;
+            operations = null;
             amount = 0.0f;
             if (texMap == null)
             {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -961,7 +961,7 @@ namespace Max2Babylon
                         // opengl norm
                         if (isBabylonExported)
                         {
-                            // texture source is OpenGL and babylon is DirectX, so we may invert Y coordinate. May void the Max operation.
+                            // texture source is OpenGL and babylon is DirectX, so we may invert Y coordinate.
                             mustInvertY = true;
                         }
                         break;
@@ -971,7 +971,7 @@ namespace Max2Babylon
                         // directx norm
                         if (isGltfExported)
                         {
-                            // texture source is DirectX and Gltf is OpenGL, so we may invert Y coordinate. May void the Max operation.
+                            // texture source is DirectX and Gltf is OpenGL, so we may invert Y coordinate.
                             mustInvertY = true;
                         }
                         break;

--- a/3ds Max/Max2Babylon/Exporter/MaxExportParameters.cs
+++ b/3ds Max/Max2Babylon/Exporter/MaxExportParameters.cs
@@ -3,6 +3,14 @@ using BabylonExport.Entities;
 
 namespace Max2Babylon
 {
+    public class MaxNormalMapParameters : NormalMapParameters
+    {
+        public static MaxNormalMapParameters Default = new MaxNormalMapParameters();
+        public const bool useMaxTransformsDefault = true;
+
+        public bool useMaxTransforms = useMaxTransformsDefault;
+    }
+
     public enum BakeAnimationType
     {
         DoNotBakeAnimation,

--- a/SharedProjects/BabylonExport.Entities/ExportParameters.cs
+++ b/SharedProjects/BabylonExport.Entities/ExportParameters.cs
@@ -3,6 +3,38 @@ using GLTFExport.Entities;
 
 namespace BabylonExport.Entities
 {
+    public enum NormalMapFormat
+    {
+        unknown = 1,
+        directx = 2,
+        opengl = 3
+    }
+
+    public enum NormalMapY
+    {
+        unknown = 1, positiv = 2, negativ = 3
+    }
+
+    public enum MapCoordinate
+    {
+        unknown = 1, right = 2, left= 3
+    }
+
+
+    public class NormalMapParameters
+    {
+        public const NormalMapY YDefault = NormalMapY.unknown;
+        public const MapCoordinate CoordinateDefault = MapCoordinate.unknown;
+
+        public NormalMapY Y = YDefault;
+        public MapCoordinate Coordinate = CoordinateDefault;
+
+        public bool IsDirectX => Y == NormalMapY.negativ && Coordinate == MapCoordinate.left;
+        public bool IsOpenGL => Y == NormalMapY.positiv && Coordinate == MapCoordinate.right;
+        public bool IsBabylon => IsDirectX;
+        public bool IsGLTF => IsOpenGL;
+    }
+
     // Define the policy use to assign format to aggregated texture such ORM
     public enum TextureFormatExportPolicy
     {

--- a/SharedProjects/Utilities/Extensions.projitems
+++ b/SharedProjects/Utilities/Extensions.projitems
@@ -21,7 +21,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)JsonTextWriterOptimized.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MathUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PathUtilities.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)TextureUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Texture\Operations\FlipChannel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Texture\Operations\InvertY.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Texture\Operations\Normalize.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Texture\Operations\SwapChannel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Texture\TextureOperation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Texture\TextureUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TreeViewExtension.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharedProjects/Utilities/Texture/Operations/FlipChannel.cs
+++ b/SharedProjects/Utilities/Texture/Operations/FlipChannel.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Utilities
+{
+    public class FlipChannel : TextureOperation
+    {
+        public const int ChannelRed = 0;
+        public const int ChannelGreen = 1;
+        public const int ChannelBlue = 2;
+
+        int _channel;
+
+        /// <summary>
+        /// Invert channel (R,G or B) using value = MAX_CHANNEL_VALUE - value.
+        /// </summary>
+        /// <param name="channel">R = 0, G = 1, B = 2</param>
+        /// <param name="name"></param>
+        /// <Exception name="ArgumentOutOfRangeException">channel value is invalid.</Exception>
+        public FlipChannel(int channel, string name = null) : base(name ?? $"i{channel}")
+        {
+            if (channel < ChannelRed || channel > ChannelBlue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channel));
+            }
+            _channel = channel;
+        }
+
+        public override void Apply(byte[] values, BitmapData infos)
+        {
+            int pixelSize = Image.GetPixelFormatSize(infos.PixelFormat) >> 3;
+            int i = 0;
+            int l = values.Length;
+            if (i < l)
+            {
+                switch (infos.PixelFormat)
+                {
+                    case PixelFormat.Canonical:
+                    case PixelFormat.Format24bppRgb:
+                    case PixelFormat.Format32bppRgb:
+                        {
+                            i += _channel;
+                            do
+                            {
+                                values[i] = (byte)(0xFF - values[i]);
+                                i += pixelSize;
+                            } while (i < l);
+                            break;
+                        }
+                    case PixelFormat.Format32bppArgb:
+                    case PixelFormat.Format32bppPArgb:
+                        {
+                            i += (_channel + 1);
+                            do
+                            {
+                                values[i] = (byte)(0xFF - values[i]);
+                                i += pixelSize;
+                            } while (i < l);
+                            break;
+                        }
+                    default:
+                        throw new NotSupportedException($"Pixel format not supported :{infos.PixelFormat}");
+                }
+            }
+        }
+    }
+}

--- a/SharedProjects/Utilities/Texture/Operations/InvertY.cs
+++ b/SharedProjects/Utilities/Texture/Operations/InvertY.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 
-namespace Utilities.Texture.Operations
+namespace Utilities
 {
     public class InvertY : TextureOperation
     {

--- a/SharedProjects/Utilities/Texture/Operations/InvertY.cs
+++ b/SharedProjects/Utilities/Texture/Operations/InvertY.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Utilities.Texture.Operations
+{
+    public class InvertY : TextureOperation
+    {
+        public InvertY(string name = null) : base(name ?? "fy")
+        {
+        }
+
+        public override void Apply(byte[] values, BitmapData infos)
+        {
+            int stride = infos.Stride;
+            int from = 0;
+            int to = (infos.Height - 1) * stride;
+
+            if (from < to)
+            {
+                byte[] tmp = new byte[infos.Stride];
+                do
+                {
+                    Array.Copy(values, to, tmp, 0, infos.Stride);
+                    Array.Copy(values, from, values, to, infos.Stride);
+                    Array.Copy(tmp, 0, values, from, infos.Stride);
+                    from += stride;
+                    to -= stride;
+                } while (from < to);
+            }
+        }
+    }
+
+}

--- a/SharedProjects/Utilities/Texture/Operations/Normalize.cs
+++ b/SharedProjects/Utilities/Texture/Operations/Normalize.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 
-namespace Utilities.Texture.Operations
+namespace Utilities
 {
     public class Normalize : TextureOperation
     {

--- a/SharedProjects/Utilities/Texture/Operations/Normalize.cs
+++ b/SharedProjects/Utilities/Texture/Operations/Normalize.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Utilities.Texture.Operations
+{
+    public class Normalize : TextureOperation
+    {
+        public Normalize(string name = null) : base(name ?? "N")
+        {
+        }
+
+        public override void Apply(byte[] values, BitmapData infos)
+        {
+            int pixelSize = Image.GetPixelFormatSize(infos.PixelFormat) >> 3;
+            int i = 0;
+            int l = values.Length;
+            if (i < l)
+            {
+                switch (infos.PixelFormat)
+                {
+                    case PixelFormat.Canonical:
+                    case PixelFormat.Format24bppRgb:
+                    case PixelFormat.Format32bppRgb:
+                        {
+                            do
+                            {
+                                var k = i;
+                                int r = values[k++];
+                                int g = values[k++];
+                                int b = values[k];
+                                var n = Math.Sqrt(r * r + g * g + b * b);
+                                values[k--] = (byte)(b / n);
+                                values[k--] = (byte)(g / n);
+                                values[k] = (byte)(r / n);
+                                i += pixelSize;
+                            } while (i < l);
+                            break;
+                        }
+                    case PixelFormat.Format32bppArgb:
+                    case PixelFormat.Format32bppPArgb:
+                        {
+                            do
+                            {
+                                var k = i + 1;
+                                int r = values[k++];
+                                int g = values[k++];
+                                int b = values[k];
+                                var n = Math.Sqrt(r * r + g * g + b * b);
+                                values[k--] = (byte)(b / n);
+                                values[k--] = (byte)(g / n);
+                                values[k] = (byte)(r / n);
+                                i += pixelSize;
+                            } while (i < l);
+                            break;
+                        }
+                    default:
+                        throw new NotSupportedException($"Pixel format not supported :{infos.PixelFormat}");
+                }
+            }
+        }
+    }
+
+}

--- a/SharedProjects/Utilities/Texture/Operations/SwapChannel.cs
+++ b/SharedProjects/Utilities/Texture/Operations/SwapChannel.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Utilities
+{
+    public class SwapChannel : TextureOperation
+    {
+        int _channelA;
+        int _channelB;
+        /// <summary>
+        /// Invert channel (R,G or B) using value = MAX_CHANNEL_VALUE - value.
+        /// </summary>
+        /// <param name="channel">R = 0, G = 1, B = 2</param>
+        /// <param name="name"></param>
+        /// <Exception name="ArgumentOutOfRangeException">channel value is invalid.</Exception>
+        public SwapChannel(int channelA, int channelB, string name = null) : base(name ?? $"s{channelA}{channelB}")
+        {
+            if (channelA < 0 || channelA > 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelA));
+            }
+            if (channelB < 0 || channelB > 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelB));
+            }
+            _channelA = channelA;
+            _channelB = channelB;
+        }
+
+        public override void Apply(byte[] values, BitmapData infos)
+        {
+            if (_channelA == _channelB)
+            {
+                return;
+            }
+            int pixelSize = Image.GetPixelFormatSize(infos.PixelFormat) >> 3;
+            int i = 0;
+            int j = 0;
+            int l = values.Length;
+            if (i < l)
+            {
+                switch (infos.PixelFormat)
+                {
+                    case PixelFormat.Canonical:
+                    case PixelFormat.Format24bppRgb:
+                    case PixelFormat.Format32bppRgb:
+                        {
+                            i += _channelA;
+                            j += _channelB;
+                            do
+                            {
+                                byte tmp = values[i];
+                                values[i] = values[j];
+                                values[j] = tmp;
+                                i += pixelSize;
+                                j += pixelSize;
+                            } while (i < l);
+                            break;
+                        }
+                    case PixelFormat.Format32bppArgb:
+                    case PixelFormat.Format32bppPArgb:
+                        {
+                            i += (_channelA + 1);
+                            j += (_channelB + 1);
+                            do
+                            {
+                                byte tmp = values[i];
+                                values[i] = values[j];
+                                values[j] = tmp;
+                                i += pixelSize;
+                                j += pixelSize;
+                            } while (i < l);
+                            break;
+                        }
+                    default:
+                        throw new NotSupportedException($"Pixel format not supported :{infos.PixelFormat}");
+                }
+            }
+        }
+    }
+
+}

--- a/SharedProjects/Utilities/Texture/TextureOperation.cs
+++ b/SharedProjects/Utilities/Texture/TextureOperation.cs
@@ -1,0 +1,17 @@
+﻿using System.Drawing.Imaging;
+
+namespace Utilities
+{
+    public abstract class TextureOperation
+    {
+        string _name;
+
+        public TextureOperation(string name)
+        {
+            _name = name ?? string.Empty;
+        }
+
+        public string Name => _name;
+        public abstract void Apply(byte[] values, BitmapData infos);
+    }
+}


### PR DESCRIPTION
Additional to previous #957 PR, finalize support for the NormalMap operation.
This allow, according to #940, to define the input format of the normal map and then allow the exporter to perform operations on the texture to export it in the correct format, targeting BabylonJS (directx) or GLTF (opengl). Resolve #940