### PR TITLE
Fixes event issue on adding attribute to normalMaps

### DIFF
--- a/3ds Max/Max2Babylon/MaterialScripts.cs
+++ b/3ds Max/Max2Babylon/MaterialScripts.cs
@@ -20,41 +20,28 @@ namespace Max2Babylon
           l = custAttributes.count mat; 
           for i = 1 to l+1 do ( 
             if(mat.custAttributes[i] != undefined) then (
-                if(mat.custAttributes[i].name == attName) then return true
-            ) ) return false )";
+                if(mat.custAttributes[i].name == attName) then
+                ( 
+                    return true
+                )
+            ) )  return false )";
 
-        /// <summary>
-        /// Note : We may run a check on all Slate view, because race condition into script execution 
-        /// do not ensure the link beetwen material and bump are correctly set when material is updated.
-        /// </summary>
-        public static string CheckBumpMap = $@"fn checkBumpMap = (
-			local babylonAttName = ""Babylon Attributes""
-			for v=1 to sme.GetNumViews() do 
-			(
-				viewNode = sme.GetView(v)
-				for i=1 to viewNode.GetNumNodes() do
-				(
-					n = viewNode.GetNode i;
-					if(classof n.reference == Normal_Bump ) then
-				    (
-					   nbump = n.reference
-					   if(hasBabylonCustomAttribute nbump babylonAttName == false ) then
-					   (
-                            {BumpMapCAtDef}
-							custAttributes.add nbump BUMP_MAP_CAT_DEF
-					   )
-					) 
-				)	
-			)        
-        )";
+        public static string CheckBumpMap = $@"fn checkBumpMap map = (
+            local babylonAttName = ""Babylon Attributes""
+            if(map != undefined) then 
+            ( 
+              if( classof map == Normal_Bump ) then
+        	  (
+        		if( hasBabylonCustomAttribute map babylonAttName == false) then
+        		(
+                    {BumpMapCAtDef}
+        			custAttributes.add map BUMP_MAP_CAT_DEF
+        		))))";
 
-        /// There is NO WAY to get an even on BumpMap creation into the Slate editor. Only Material creation is triggered.
-        /// This is the reason we listen for parameters Material change
         private static string AddPhysicalBabylonUI =
         $@"if ( hasBabylonCustomAttribute maxMaterial ""Babylon Attributes"" == false) then ( 
-              {PhysicalBabylonCAtDef}
+             {PhysicalBabylonCAtDef}
               custAttributes.add maxMaterial PHYSICAL_MATERIAL_CAT_DEF 
-              when parameters maxMaterial change do checkBumpMap()
         )";
 
         public static string AddCallback => $@"addMaterialCallbackScript = ""maxMaterial = callbacks.notificationParam();

--- a/3ds Max/Max2Babylon/Scripts/PHYSICAL_MATERIAL_CAT_DEF.ms
+++ b/3ds Max/Max2Babylon/Scripts/PHYSICAL_MATERIAL_CAT_DEF.ms
@@ -52,7 +52,10 @@ version:2
         on BumpBtn pressed do
         (
             local activMaterial =  sme.GetMtlInParamEditor()
-            checkBumpMap(activMaterial.bump_map)
+            -- for PhysicalMaterial
+            if( hasProperty activMaterial "bump_map" ) then checkBumpMap(activMaterial.bump_map)
+            -- for PBRMetalRough and PBRSpecGloss
+            if( hasProperty activMaterial "norm_map" ) then checkBumpMap(activMaterial.norm_map)
         )
     )    
 )

--- a/3ds Max/Max2Babylon/Scripts/PHYSICAL_MATERIAL_CAT_DEF.ms
+++ b/3ds Max/Max2Babylon/Scripts/PHYSICAL_MATERIAL_CAT_DEF.ms
@@ -47,5 +47,12 @@ version:2
         label babylonTransparencyMode_label "Transparency Mode " Align: #Left across:2
         dropdownlist babylonTransparencyMode_dd  items:# ("Opaque","Cutoff","Blend") selection:(babylonTransparencyMode+1) Align: #Right
         on babylonTransparencyMode_dd selected i do babylonTransparencyMode = i-1
+
+        button BumpBtn  "Add Normal bump(s) attributes" tooltip:"Adds additional attributes to normal maps to help the exporter manage the input format."
+        on BumpBtn pressed do
+        (
+            local activMaterial =  sme.GetMtlInParamEditor()
+            checkBumpMap(activMaterial.bump_map)
+        )
     )    
 )


### PR DESCRIPTION
In some cases, when loading a scene, the new automatic way of adding custom attributes to Normal Bump leads to a stack overflow (mainly due to multi-threaded racing). In addition, this method was too cumbersome when a scene had a lot of material, degrading performance.
We modify this behavior by adding a specific button to the materials panel.
![image](https://user-images.githubusercontent.com/22658224/121564708-0e22f880-ca1c-11eb-840b-2d240f3d1508.png)

