### PR TITLE
supress duplicate scale

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -63,7 +63,6 @@ namespace Babylon2GLTF
 
                 // Switch coordinate system at object level
                 globalVertex.Position.Z *= -1;
-                globalVertex.Position *= exportParameters.scaleFactor;
 
                 if (hasNormals)
                 {


### PR DESCRIPTION
In place scale has been left inside the code, when the scale is defined now at root level.