### PR TITLE
gltf skin inverse matrix corrupted

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -32,7 +32,6 @@ namespace Max2Babylon
 
         public const int MaxSceneTicksPerSecond = 4800; //https://knowledge.autodesk.com/search-result/caas/CloudHelp/cloudhelp/2016/ENU/MAXScript-Help/files/GUID-141213A1-B5A8-457B-8838-E602022C8798-htm.html
 
-
         public void CheckCancelled()
         {
             Application.DoEvents();
@@ -567,41 +566,38 @@ namespace Max2Babylon
                 }
             }
 
-            if (exportParameters.scaleFactor != 1.0f)
+            RaiseMessage(String.Format("A root node is added to globally scale the scene by {0}", exportParameters.scaleFactor), 1);
+
+            // Create root node for scaling
+            BabylonMesh rootNode = new BabylonMesh { name = "root", id = Guid.NewGuid().ToString() };
+            rootNode.isDummy = true;
+            float rootNodeScale = exportParameters.scaleFactor;
+            rootNode.scaling = new float[3] { rootNodeScale, rootNodeScale, rootNodeScale };
+
+            if (ExportQuaternionsInsteadOfEulers)
             {
-                RaiseMessage(String.Format("A root node is added to globally scale the scene by {0}", exportParameters.scaleFactor), 1);
-
-                // Create root node for scaling
-                BabylonMesh rootNode = new BabylonMesh { name = "root", id = Guid.NewGuid().ToString() };
-                rootNode.isDummy = true;
-                float rootNodeScale = exportParameters.scaleFactor;
-                rootNode.scaling = new float[3] { rootNodeScale, rootNodeScale, rootNodeScale };
-
-                if (ExportQuaternionsInsteadOfEulers)
-                {
-                    rootNode.rotationQuaternion = new float[] { 0, 0, 0, 1 };
-                }
-                else
-                {
-                    rootNode.rotation = new float[] { 0, 0, 0 };
-                }
-
-                // Update all top nodes
-                var babylonNodes = new List<BabylonNode>();
-                babylonNodes.AddRange(babylonScene.MeshesList);
-                babylonNodes.AddRange(babylonScene.CamerasList);
-                babylonNodes.AddRange(babylonScene.LightsList);
-                foreach (BabylonNode babylonNode in babylonNodes)
-                {
-                    if (babylonNode.parentId == null)
-                    {
-                        babylonNode.parentId = rootNode.id;
-                    }
-                }
-
-                // Store root node
-                babylonScene.MeshesList.Add(rootNode);
+                rootNode.rotationQuaternion = new float[] { 0, 0, 0, 1 };
             }
+            else
+            {
+                rootNode.rotation = new float[] { 0, 0, 0 };
+            }
+
+            // Update all top nodes
+            var babylonNodes = new List<BabylonNode>();
+            babylonNodes.AddRange(babylonScene.MeshesList);
+            babylonNodes.AddRange(babylonScene.CamerasList);
+            babylonNodes.AddRange(babylonScene.LightsList);
+            foreach (BabylonNode babylonNode in babylonNodes)
+            {
+                if (babylonNode.parentId == null)
+                {
+                    babylonNode.parentId = rootNode.id;
+                }
+            }
+
+            // Store root node
+            babylonScene.MeshesList.Add(rootNode);
 #if DEBUG
             var nodesExportTime = watch.ElapsedMilliseconds / 1000.0 - flattenTime;
             RaiseMessage($"Nodes exported in {nodesExportTime:0.00}s", Color.Blue);

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -63,7 +63,6 @@ namespace Babylon2GLTF
 
                 // Switch coordinate system at object level
                 globalVertex.Position.Z *= -1;
-                globalVertex.Position *= exportParameters.scaleFactor;
 
                 if (hasNormals)
                 {

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Skin.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Skin.cs
@@ -93,8 +93,10 @@ namespace Babylon2GLTF
             );
             gltfSkin.inverseBindMatrices = accessorInverseBindMatrices.index;
 
-            // World matrix of the node
-            var nodeWorldMatrix = _getNodeWorldMatrix(gltfNode);
+            // World matrix of the node. Tell the exporter to avoid the root, otherwise the 
+            // inverseBindMatrices will be corrupted by this transformation purpose only matrix
+            // added at Babylon tree level.
+            var nodeWorldMatrix = _getNodeWorldMatrix(gltfNode, true);
 
             var gltfJoints = new List<int>();
 
@@ -185,33 +187,32 @@ namespace Babylon2GLTF
             );
         }
 
-        private BabylonMatrix _getNodeWorldMatrix(GLTFNode gltfNode)
+        private BabylonMatrix _getNodeWorldMatrix(GLTFNode gltfNode, bool avoidRoot = false)
         {
             if (gltfNode.parent == null)
             {
-                return _getNodeLocalMatrix(gltfNode);
+                return avoidRoot? BabylonMatrix.Identity():_getNodeLocalMatrix(gltfNode);
             }
-            else
-            {
-                return _getNodeLocalMatrix(gltfNode) * _getNodeWorldMatrix(gltfNode.parent);
-            }
+            return _getNodeLocalMatrix(gltfNode) * _getNodeWorldMatrix(gltfNode.parent, avoidRoot);
         }
 
-        private BabylonMatrix _getBoneWorldMatrix(BabylonBone babylonBone, List<BabylonBone> bones)
-        {
-            var boneLocalMatrix = new BabylonMatrix();
-            boneLocalMatrix.m = babylonBone.matrix;
-            if (babylonBone.parentBoneIndex == -1)
-            {
-                return boneLocalMatrix;
-            }
-            else
-            {
-                var parentBabylonBone = bones.Find(bone => bone.index == babylonBone.parentBoneIndex);
-                var parentWorldMatrix = _getBoneWorldMatrix(parentBabylonBone, bones);
-                return boneLocalMatrix * parentWorldMatrix;
-            }
-        }
+        // TODO clean up
+
+        //private BabylonMatrix _getBoneWorldMatrix(BabylonBone babylonBone, List<BabylonBone> bones)
+        //{
+        //    var boneLocalMatrix = new BabylonMatrix();
+        //    boneLocalMatrix.m = babylonBone.matrix;
+        //    if (babylonBone.parentBoneIndex == -1)
+        //    {
+        //        return boneLocalMatrix;
+        //    }
+        //    else
+        //    {
+        //        var parentBabylonBone = bones.Find(bone => bone.index == babylonBone.parentBoneIndex);
+        //        var parentWorldMatrix = _getBoneWorldMatrix(parentBabylonBone, bones);
+        //        return boneLocalMatrix * parentWorldMatrix;
+        //    }
+        //}
 
         // TODO clean up
         private BabylonMatrix _removeScale(BabylonMatrix boneWorldMatrix)


### PR DESCRIPTION
When adding a scale at the root of the scene, every skin inverse matrix get corrupted by the WorldTransform of this root. 
To avoid this, we systematically add a root node to the scene, even without scale factor, and bypass the root to compute the WorldTransform matrix of the skinned node.
This is a quick fix, BUT, the entire mathematics for skinning  has to be review.
At Babylon level AND Gltf Level, where the code is not clear at all, and there is a mixed up of local inverse and world transform when skinned mesh isnt at root level
We must first review the Babylon part, then GLTF which is based on Babylon exported scene.