### PR TITLE
Update Id and description of the action item

### DIFF
--- a/3ds Max/Max2Babylon/BabylonAnimationActionItem.cs
+++ b/3ds Max/Max2Babylon/BabylonAnimationActionItem.cs
@@ -59,10 +59,7 @@ namespace Max2Babylon
             }
         }
 
-		public override int Id_
-		{
-			get { return 2; }
-		}
+		public override int Id_ => 3;
 
 		public override string ButtonText
 		{
@@ -76,7 +73,7 @@ namespace Max2Babylon
 
 		public override string DescriptionText
 		{
-			get { return "UI to manage babylon animation groups for this scene"; }
+			get { return "Babylon - manage animation groups for this scene"; }
 		}
 
 		public override string CategoryText

--- a/3ds Max/Max2Babylon/BabylonExportActionItem.cs
+++ b/3ds Max/Max2Babylon/BabylonExportActionItem.cs
@@ -39,10 +39,7 @@ namespace Max2Babylon
             form = null;
         }
 
-        public override int Id_
-        {
-            get { return 1; }
-        }
+        public override int Id_ => 1;
 
         public override string ButtonText
         {
@@ -56,7 +53,7 @@ namespace Max2Babylon
 
         public override string DescriptionText
         {
-            get { return "Generate a babylon.js scene file2"; }
+            get { return "Babylon - Generate a babylon.js scene file2"; }
         }
 
         public override string CategoryText

--- a/3ds Max/Max2Babylon/BabylonLoadAnimations.cs
+++ b/3ds Max/Max2Babylon/BabylonLoadAnimations.cs
@@ -31,11 +31,7 @@ namespace Max2Babylon
             return;
         }
 
-        public override int Id_
-        {
-            get { return 1; }
-        }
-
+        public override int Id_ => 5;
         public override string ButtonText
         {
             get { return "Babylon Load AnimationGroups"; }
@@ -59,7 +55,7 @@ namespace Max2Babylon
 
         public override string DescriptionText
         {
-            get { return "Load AnimationGroups from Scnene or selected Containers"; }
+            get { return "Babylon - Load AnimationGroups from Scnene or selected Containers"; }
         }
 
         public override string CategoryText

--- a/3ds Max/Max2Babylon/BabylonPropertiesActionItem.cs
+++ b/3ds Max/Max2Babylon/BabylonPropertiesActionItem.cs
@@ -48,10 +48,7 @@ namespace Max2Babylon
 
         }
 
-        public override int Id_
-        {
-            get { return 1; }
-        }
+        public override int Id_ => 2;
 
         public override string ButtonText
         {
@@ -65,7 +62,7 @@ namespace Max2Babylon
 
         public override string DescriptionText
         {
-            get { return "UI for setting Babylon.js specific properties"; }
+            get { return "Babylon - setting specific properties"; }
         }
 
         public override string CategoryText

--- a/3ds Max/Max2Babylon/BabylonSkipFlatten.cs
+++ b/3ds Max/Max2Babylon/BabylonSkipFlatten.cs
@@ -22,10 +22,7 @@ namespace Max2Babylon
             return;
         }
 
-        public override int Id_
-        {
-            get { return 1; }
-        }
+        public override int Id_ => 6;
 
         public override string ButtonText
         {
@@ -53,7 +50,7 @@ namespace Max2Babylon
 
         public override string DescriptionText
         {
-            get { return "Toggle skip flatten status"; }
+            get { return "Babylon - Toggle skip flatten status"; }
         }
 
         public override string CategoryText

--- a/3ds Max/Max2Babylon/BabylonStoreAnimations.cs
+++ b/3ds Max/Max2Babylon/BabylonStoreAnimations.cs
@@ -33,10 +33,7 @@ namespace Max2Babylon
             return;
         }
 
-        public override int Id_
-        {
-            get { return 1; }
-        }
+        public override int Id_ => 4;
 
         public override string ButtonText
         {
@@ -61,7 +58,7 @@ namespace Max2Babylon
 
         public override string DescriptionText
         {
-            get { return "Copy AnimationGroups into a BabylonAnimationHelper or a BabylonContainerHelper"; }
+            get { return "Babylon - Copy AnimationGroups into a BabylonAnimationHelper or a BabylonContainerHelper"; }
         }
 
         public override string CategoryText


### PR DESCRIPTION
ActionItems was not available into ActionTable, because of duplicate Id (Id must be unique within an ActionTable). 
Prefix all related textual descriptions with "Babylon", in order to group the Items when editing with the Shortcut Key editor. Fix #974 