### PR TITLE
Update Optimize Vertices label and checkbox behavior

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -390,7 +390,7 @@ namespace Max2Babylon
                 var hasColor = unskinnedMesh.NumberOfColorVerts > 0;
                 var hasAlpha = unskinnedMesh.GetNumberOfMapVerts(-2) > 0;
 
-                var optimizeVertices = meshNode.MaxNode.GetBoolProperty("babylonjs_optimizevertices");
+                var optimizeVertices = !meshNode.MaxNode.GetBoolProperty("babylonjs_quickexport");
 
                 var invertedWorldMatrix = GetInvertWorldTM(meshNode, 0);
                 var offsetTM = GetOffsetTM(meshNode, 0);

--- a/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.Designer.cs
+++ b/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.Designer.cs
@@ -259,7 +259,7 @@ namespace Max2Babylon
             this.chkOptimize.Name = "chkOptimize";
             this.chkOptimize.Size = new System.Drawing.Size(131, 17);
             this.chkOptimize.TabIndex = 14;
-            this.chkOptimize.Text = "Try to optimize vertices";
+            this.chkOptimize.Text = "Quick Export (unoptimized)";
             this.chkOptimize.ThreeState = true;
             this.chkOptimize.UseVisualStyleBackColor = true;
             // 

--- a/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ObjectPropertiesForm.cs
@@ -19,7 +19,7 @@ namespace Max2Babylon
             Tools.UpdateCheckBox(chkNoExport, objects, "babylonjs_noexport");
             Tools.UpdateCheckBox(chkCollisions, objects, "babylonjs_checkcollisions");
             Tools.UpdateCheckBox(chkPickable, objects, "babylonjs_checkpickable");
-            Tools.UpdateCheckBox(chkOptimize, objects, "babylonjs_optimizevertices");
+            Tools.UpdateCheckBox(chkOptimize, objects, "babylonjs_quickexport");
             Tools.UpdateCheckBox(chkShowBoundingBox, objects, "babylonjs_showboundingbox");
             Tools.UpdateCheckBox(chkShowSubMeshesBoundingBox, objects, "babylonjs_showsubmeshesboundingbox");
 
@@ -75,7 +75,7 @@ namespace Max2Babylon
             Tools.PrepareCheckBox(chkNoExport, objects, "babylonjs_noexport");
             Tools.PrepareCheckBox(chkCollisions, objects, "babylonjs_checkcollisions");
             Tools.PrepareCheckBox(chkPickable, objects, "babylonjs_checkpickable");
-            Tools.PrepareCheckBox(chkOptimize, objects, "babylonjs_optimizevertices");
+            Tools.PrepareCheckBox(chkOptimize, objects, "babylonjs_quickexport", 1);
             Tools.PrepareCheckBox(chkShowBoundingBox, objects, "babylonjs_showboundingbox");
             Tools.PrepareCheckBox(chkShowSubMeshesBoundingBox, objects, "babylonjs_showsubmeshesboundingbox");
 


### PR DESCRIPTION
fix #970 
The text is too wide, we must choose something else. Quick Export (draft) ?
![image](https://user-images.githubusercontent.com/22658224/123830766-e8469080-d903-11eb-8f66-6b92102be73f.png)
