### PR TITLE
correct KHR_TextureTransform warn

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -259,7 +259,7 @@ namespace Babylon2GLTF
                     gltfTextureInfo.scale = babylonTexture.level;
                 }
 
-                if (!(babylonTexture.uOffset == 0) || !(babylonTexture.vOffset == 0) || !(babylonTexture.uScale == 1) || !(babylonTexture.vScale == 1) || !(babylonTexture.wAng == 0))
+                if (!(babylonTexture.uOffset == 0) || !(babylonTexture.vOffset == 0) || !(babylonTexture.uScale == 1) || !(babylonTexture.vScale == -1) || !(babylonTexture.wAng == 0))
                 {
                     // Add texture extension if enabled in the export settings
                     if (exportParameters.enableKHRTextureTransform)
@@ -268,7 +268,6 @@ namespace Babylon2GLTF
                     }
                     else
                     {
-                        logger.RaiseWarning("GLTFExporter.Texture | KHR_texture_transform is not enabled, so the texture may look incorrect at runtime!", 3);
                         logger.RaiseWarning("GLTFExporter.Texture | KHR_texture_transform is not enabled, so the texture may look incorrect at runtime!", 3);
                     }
                 }


### PR DESCRIPTION
the exporter warns about a disabled KHR_texture_transform when the bitmaps have no transforms applied.
VScale is set to -1 for Babylon export then the sign is flipped again for the Babylon2Gltf transformation.
However prior to this, the test for the KHR_TextureTransform was made against 1 for Babylon.VScale.
Also, we remove the duplicate warning message.
fix #986 