### PR TITLE
Discard local "relative" path to gltf image uri when located in same folder than model

### DIFF
--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -177,7 +177,7 @@ namespace Babylon2GLTF
                     if (!string.IsNullOrWhiteSpace(exportParameters.textureFolder))
                     {
                         textureUri = PathUtilities.GetRelativePath( exportParameters.outputPath,exportParameters.textureFolder);
-                        textureUri = Path.Combine(textureUri, ImageName);
+                        textureUri = IsLocalRootPath(textureUri) ? ImageName : Path.Combine(textureUri, ImageName);
                     }
                     gltfImage = new GLTFImage
                     {
@@ -266,7 +266,6 @@ namespace Babylon2GLTF
                 if (CheckIfImageIsRegistered(textureID))
                 {
                     var textureComponent = GetRegisteredTexture(textureID);
-
                     return textureComponent;
                 }
 
@@ -277,6 +276,8 @@ namespace Babylon2GLTF
                 return gltfTextureInfo;
             }
         }
+
+        private bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo("./") == 0 || path.CompareTo(".") == 0;
 
         private string TextureTransformID(GLTFTextureInfo gltfTextureInfo)
         {

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -177,7 +177,7 @@ namespace Babylon2GLTF
                     if (!string.IsNullOrWhiteSpace(exportParameters.textureFolder))
                     {
                         textureUri = PathUtilities.GetRelativePath( exportParameters.outputPath,exportParameters.textureFolder);
-                        textureUri = IsLocalRootPath(textureUri) ? ImageName : Path.Combine(textureUri, ImageName);
+                        textureUri = PathUtilities.IsLocalRootPath(textureUri) ? ImageName : Path.Combine(textureUri, ImageName);
                     }
                     gltfImage = new GLTFImage
                     {
@@ -277,7 +277,6 @@ namespace Babylon2GLTF
             }
         }
 
-        private bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo("./") == 0 || path.CompareTo(".") == 0;
 
         private string TextureTransformID(GLTFTextureInfo gltfTextureInfo)
         {

--- a/SharedProjects/Utilities/PathUtilities.cs
+++ b/SharedProjects/Utilities/PathUtilities.cs
@@ -8,6 +8,7 @@ namespace Utilities
     {
         public static string LocalDir = ".";
         public static string LocalDirPath = $"{LocalDir}{Path.DirectorySeparatorChar}";
+        public static string AltLocalDirPath = $"{LocalDir}{Path.AltDirectorySeparatorChar}";
 
         /// <summary>
         /// Creates a relative path from one file or folder to another. Input paths that are directories should have a trailing slash.
@@ -69,7 +70,7 @@ namespace Utilities
             //source: https://stackoverflow.com/a/146162/301388
         }
 
-        public static bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo(LocalDirPath) == 0 || path.CompareTo(LocalDir) == 0;
+        public static bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo(AltLocalDirPath) == 0 || path.CompareTo(LocalDirPath) == 0 || path.CompareTo(LocalDir) == 0;
     }
 
 

--- a/SharedProjects/Utilities/PathUtilities.cs
+++ b/SharedProjects/Utilities/PathUtilities.cs
@@ -66,6 +66,8 @@ namespace Utilities
             return r.Replace(fileName, "_");
             //source: https://stackoverflow.com/a/146162/301388
         }
+
+        public static bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo("./") == 0 || path.CompareTo(".") == 0;
     }
 
 

--- a/SharedProjects/Utilities/PathUtilities.cs
+++ b/SharedProjects/Utilities/PathUtilities.cs
@@ -6,6 +6,8 @@ namespace Utilities
 {
     static class PathUtilities
     {
+        public static string LocalDir = ".";
+        public static string LocalDirPath = $"{LocalDir}{Path.DirectorySeparatorChar}";
 
         /// <summary>
         /// Creates a relative path from one file or folder to another. Input paths that are directories should have a trailing slash.
@@ -67,7 +69,7 @@ namespace Utilities
             //source: https://stackoverflow.com/a/146162/301388
         }
 
-        public static bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo("./") == 0 || path.CompareTo(".") == 0;
+        public static bool IsLocalRootPath(string path) => string.IsNullOrEmpty(path) || path.CompareTo(LocalDirPath) == 0 || path.CompareTo(LocalDir) == 0;
     }
 
 


### PR DESCRIPTION
fix #985 
assuming the image name is a base file name 
We introduce local test to verify that the root path is not "./" nor "."

`./name.png` will become name.png
`./<path>/name.png` or other relative/absolute  path will stay same.

