### PR TITLE
pass selected flags to scene initialization

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -291,7 +291,7 @@ namespace Max2Babylon
             var gameScene = Loader.Global.IGameInterface;
             if (exportNode == null || exportNode.IsRootNode)
             {
-                gameScene.InitialiseIGame(false);
+                gameScene.InitialiseIGame(exportParameters.exportOnlySelected);
             }
             else
             {


### PR DESCRIPTION
When initialize the scene, use the "only selected" flag instead of systematic false
 `              gameScene.InitialiseIGame(exportParameters.exportOnlySelected);
`
the result is the optimization of the scene export. We no longer have to go through all the nodes to test if they are selected.
When the scene encompasses thousands of meshes, it changes the game.  
fix #997 
