### PR TITLE
Texture transform support for both babylon and gltf format

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -1218,21 +1218,29 @@ namespace Max2Babylon
 
      
  
-            //note: Max is defining offset displacement when Babylon is defining origin of the texture
-            //positiv offset in Max mean Negative offset in Babylon(Inverse transform)
-            var offset = new BabylonVector3(-uvGen.GetUOffs(0), -uvGen.GetVOffs(0), 0);
+            var offset = new BabylonVector3(uvGen.GetUOffs(0), uvGen.GetVOffs(0), 0);
             var scale = new BabylonVector3(uvGen.GetUScl(0), uvGen.GetVScl(0), 1);
-            //max rotation is horlogic, while here we move using trigonometric, so anti - horlogic
+            //max rotation is horlogic, here we move using trigonometric, so anti - horlogic
             var rotationEuler = new BabylonVector3(-uvGen.GetUAng(0), -uvGen.GetVAng(0), -uvGen.GetWAng(0));
             
             var center = new BabylonVector3(0.5f, 0.5f, 0); // max ref is center of the texture
-            var pivot = center - offset;
+            var pivot = center + offset;
 
             if (this.isBabylonExported)
             {
                 // rotation center is very specific to babylon
                 babylonTexture.uRotationCenter = pivot.X;
                 babylonTexture.vRotationCenter = pivot.Y;
+                if( Math.Abs(scale.X) != 1 || Math.Abs(scale.Y) != 1)
+                {
+                    var translate = BabylonMatrix.Translation(-center);
+                    var scaling = BabylonMatrix.Scale(scale);
+                    var t = translate * scaling ;
+                    offset = offset * t;
+                }
+                //note: Max is defining offset displacement when Babylon is defining origin of the texture
+                //positiv offset in Max mean Negative offset in Babylon(Inverse transform)
+                offset = -offset;
             }
             else
             {
@@ -1249,7 +1257,7 @@ namespace Max2Babylon
                 offset = origin * t;
             }
             babylonTexture.uOffset = offset.X;
-            babylonTexture.vOffset = 1-offset.Y;
+            babylonTexture.vOffset = (1 - offset.Y);
             babylonTexture.uScale = scale.X;
             babylonTexture.vScale = -scale.Y; // reverse V - Max to Babylon 
             babylonTexture.invertY = false; // do not use invert y which is very Babylon specific, keep the math as it.

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -1242,9 +1242,10 @@ namespace Max2Babylon
                 // inverse transforms to change reference 
                 var translateToOrigin = BabylonMatrix.Translation(-pivot);
                 var rotate = BabylonMatrix.RotationZ(-rotationEuler.Z);
+                var scaling = BabylonMatrix.Scale(scale);
                 // because we want to keep the offset, so bring back to the center
                 var translateBack = BabylonMatrix.Translation(center);
-                var t = translateToOrigin * rotate * translateBack ;
+                var t = translateToOrigin * scaling * rotate * translateBack ;
                 offset = origin * t;
             }
             babylonTexture.uOffset = offset.X;

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -1227,13 +1227,13 @@ namespace Max2Babylon
             
             var center = new BabylonVector3(0.5f, 0.5f, 0); // max ref is center of the texture
             var pivot = center - offset;
-            
+
             if (this.isBabylonExported)
             {
-                 // rotation center is very specific to webGL, so using lower left corner as reference 
+                // rotation center is very specific to babylon
                 babylonTexture.uRotationCenter = pivot.X;
                 babylonTexture.vRotationCenter = pivot.Y;
-            } 
+            }
             else
             {
                 // might be something it did not support RotationCenter
@@ -1249,7 +1249,7 @@ namespace Max2Babylon
                 offset = origin * t;
             }
             babylonTexture.uOffset = offset.X;
-            babylonTexture.vOffset = 1 - offset.Y;
+            babylonTexture.vOffset = 1-offset.Y;
             babylonTexture.uScale = scale.X;
             babylonTexture.vScale = -scale.Y; // reverse V - Max to Babylon 
             babylonTexture.invertY = false; // do not use invert y which is very Babylon specific, keep the math as it.

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -1228,7 +1228,8 @@ namespace Max2Babylon
 
             if (this.isBabylonExported)
             {
-                // rotation center is very specific to babylon
+                // fast and optimized track for Babylon format. using Matrix transform
+                // https://github.com/BabylonJS/Babylon.js/blob/master/src/Materials/Textures/texture.ts#L561-L640
                 babylonTexture.uRotationCenter = pivot.X;
                 babylonTexture.vRotationCenter = pivot.Y;
                 if( Math.Abs(scale.X) != 1 || Math.Abs(scale.Y) != 1)
@@ -1241,11 +1242,11 @@ namespace Max2Babylon
                 //note: Max is defining offset displacement when Babylon is defining origin of the texture
                 //positiv offset in Max mean Negative offset in Babylon(Inverse transform)
                 offset = -offset;
+                scale.Y = -scale.Y;
             }
-            else
+            else 
             {
-                // might be something it did not support RotationCenter
-                // update offset accordingly
+                // lets define we have to set the offset manually without the help of rotation center
                 var origin = new BabylonVector3(0, 1f, 0); // upper left corner
                 // inverse transforms to change reference 
                 var translateToOrigin = BabylonMatrix.Translation(-pivot);
@@ -1255,12 +1256,13 @@ namespace Max2Babylon
                 var translateBack = BabylonMatrix.Translation(center);
                 var t = translateToOrigin * scaling * rotate * translateBack ;
                 offset = origin * t;
-            }
-            babylonTexture.uOffset = offset.X;
-            babylonTexture.vOffset = (1 - offset.Y);
+             }
+
+            babylonTexture.uOffset = offset.X%1;
+            babylonTexture.vOffset = (1 - offset.Y) % 1;
             babylonTexture.uScale = scale.X;
-            babylonTexture.vScale = -scale.Y; // reverse V - Max to Babylon 
-            babylonTexture.invertY = false; // do not use invert y which is very Babylon specific, keep the math as it.
+            babylonTexture.vScale = scale.Y; 
+            babylonTexture.invertY = false; 
             babylonTexture.uAng = rotationEuler.X;
             babylonTexture.vAng = rotationEuler.Y;
             babylonTexture.wAng = rotationEuler.Z;

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Texture.cs
@@ -1239,7 +1239,7 @@ namespace Max2Babylon
                 // might be something it did not support RotationCenter
                 // update offset accordingly
                 var origin = new BabylonVector3(0, 1f, 0); // upper left corner
-                // inverse transfoorms to change reference 
+                // inverse transforms to change reference 
                 var translateToOrigin = BabylonMatrix.Translation(-pivot);
                 var rotate = BabylonMatrix.RotationZ(-rotationEuler.Z);
                 // because we want to keep the offset, so bring back to the center

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -465,8 +465,8 @@ namespace Babylon2GLTF
                 return false;
             }
 
-            var uOffset = babylonTexture.uOffset % 1;
             // according to specification (https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#images) : The origin of the UV coordinates (0, 0) corresponds to the upper left corner of a texture image
+            var uOffset = babylonTexture.uOffset % 1;
             var vOffset = babylonTexture.vOffset % 1;
             var uScale  = babylonTexture.uScale;
             var vScale  = -babylonTexture.vScale;

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -466,11 +466,11 @@ namespace Babylon2GLTF
             }
 
             // according to specification (https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#images) : The origin of the UV coordinates (0, 0) corresponds to the upper left corner of a texture image
-            var uOffset = babylonTexture.uOffset % 1;
-            var vOffset = babylonTexture.vOffset % 1;
+            var uOffset = babylonTexture.uOffset ;
+            var vOffset = babylonTexture.vOffset ;
             var uScale  = babylonTexture.uScale;
-            var vScale  = -babylonTexture.vScale;
-            var wAng    = -babylonTexture.wAng;
+            var vScale  = babylonTexture.vScale;
+            var wAng    = -babylonTexture.wAng; // trigo to horlogic
 
             // Add texture extension only if needed
             if (uOffset == 0 && vOffset == 0 && uScale == 1 && Math.Abs(vScale) == 1 && Math.Abs(wAng) == 0)

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Texture.cs
@@ -458,25 +458,26 @@ namespace Babylon2GLTF
         /// <param name="babylonMaterial"></param>
         private bool TryAddTextureTransformExtension(ref GLTF gltf, ref GLTFTextureInfo gltfTextureInfo, BabylonTexture babylonTexture)
         {
-            var uOffset = babylonTexture.uOffset;
-            var vOffset = -babylonTexture.vOffset;
-            var uScale = babylonTexture.uScale;
-            var vScale = -babylonTexture.vScale;
-            var wAng =  babylonTexture.wAng;
-
-            // Add texture extension only if needed
-            if (uOffset == 0 && vOffset == 0 && uScale == 1 && vScale == 1 && babylonTexture.wAng == 0)
-            {
-                return false;
-            }
-
             // Add texture extension if enabled in the export settings
             if (!exportParameters.enableKHRTextureTransform)
             {
                 logger.RaiseWarning("GLTFExporter.Texture | KHR_texture_transform is not enabled, so the texture may look incorrect at runtime!", 3);
                 return false;
             }
- 
+
+            var uOffset = babylonTexture.uOffset % 1;
+            // according to specification (https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#images) : The origin of the UV coordinates (0, 0) corresponds to the upper left corner of a texture image
+            var vOffset = babylonTexture.vOffset % 1;
+            var uScale  = babylonTexture.uScale;
+            var vScale  = -babylonTexture.vScale;
+            var wAng    = -babylonTexture.wAng;
+
+            // Add texture extension only if needed
+            if (uOffset == 0 && vOffset == 0 && uScale == 1 && Math.Abs(vScale) == 1 && Math.Abs(wAng) == 0)
+            {
+                return false;
+            }
+
             // finally add texture extension
             if (!gltf.extensionsUsed.Contains(KHR_texture_transform))
             {

--- a/SharedProjects/BabylonExport.Entities/BabylonMatrix.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMatrix.cs
@@ -9,7 +9,8 @@ namespace BabylonExport.Entities
         /**
          * Returns a new Matrix as the passed inverted one.  
          */
-        public static BabylonMatrix Invert(BabylonMatrix source) {
+        public static BabylonMatrix Invert(BabylonMatrix source)
+        {
             var result = new BabylonMatrix();
             source.invertToRef(result);
             return result;
@@ -24,12 +25,18 @@ namespace BabylonExport.Entities
             result.setTranslation(translation);
             return result;
         }
-
+        public static BabylonMatrix RotationZ(float rad)
+        {
+            var rotate = new BabylonMatrix();
+            var q = BabylonQuaternion.FromEulerAngles(0, 0, rad).toRotationMatrix(rotate);
+            return rotate;
+        }
         /**
          * Inverts in place the Matrix.  
          * Returns the Matrix inverted.  
          */
-        public BabylonMatrix invert() {
+        public BabylonMatrix invert()
+        {
             this.invertToRef(this);
             return this;
         }
@@ -38,7 +45,8 @@ namespace BabylonExport.Entities
          * Sets the passed matrix with the current inverted Matrix.  
          * Returns the unmodified current Matrix.  
          */
-        public BabylonMatrix invertToRef(BabylonMatrix other) {
+        public BabylonMatrix invertToRef(BabylonMatrix other)
+        {
             var l1 = this.m[0];
             var l2 = this.m[1];
             var l3 = this.m[2];
@@ -79,23 +87,23 @@ namespace BabylonExport.Entities
             var l38 = (l5 * l11) - (l7 * l9);
             var l39 = (l5 * l10) - (l6 * l9);
 
-            other.m[0] = l23* l27;
-            other.m[4] = l24* l27;
-            other.m[8] = l25* l27;
-            other.m[12] = l26* l27;
-            other.m[1] = -(((l2* l17) - (l3* l18)) + (l4* l19)) * l27;
-            other.m[5] = (((l1* l17) - (l3* l20)) + (l4* l21)) * l27;
-            other.m[9] = -(((l1* l18) - (l2* l20)) + (l4* l22)) * l27;
-            other.m[13] = (((l1* l19) - (l2* l21)) + (l3* l22)) * l27;
-            other.m[2] = (((l2* l28) - (l3* l29)) + (l4* l30)) * l27;
-            other.m[6] = -(((l1* l28) - (l3* l31)) + (l4* l32)) * l27;
-            other.m[10] = (((l1* l29) - (l2* l31)) + (l4* l33)) * l27;
-            other.m[14] = -(((l1* l30) - (l2* l32)) + (l3* l33)) * l27;
-            other.m[3] = -(((l2* l34) - (l3* l35)) + (l4* l36)) * l27;
-            other.m[7] = (((l1* l34) - (l3* l37)) + (l4* l38)) * l27;
-            other.m[11] = -(((l1* l35) - (l2* l37)) + (l4* l39)) * l27;
-            other.m[15] = (((l1* l36) - (l2* l38)) + (l3* l39)) * l27;
-            
+            other.m[0] = l23 * l27;
+            other.m[4] = l24 * l27;
+            other.m[8] = l25 * l27;
+            other.m[12] = l26 * l27;
+            other.m[1] = -(((l2 * l17) - (l3 * l18)) + (l4 * l19)) * l27;
+            other.m[5] = (((l1 * l17) - (l3 * l20)) + (l4 * l21)) * l27;
+            other.m[9] = -(((l1 * l18) - (l2 * l20)) + (l4 * l22)) * l27;
+            other.m[13] = (((l1 * l19) - (l2 * l21)) + (l3 * l22)) * l27;
+            other.m[2] = (((l2 * l28) - (l3 * l29)) + (l4 * l30)) * l27;
+            other.m[6] = -(((l1 * l28) - (l3 * l31)) + (l4 * l32)) * l27;
+            other.m[10] = (((l1 * l29) - (l2 * l31)) + (l4 * l33)) * l27;
+            other.m[14] = -(((l1 * l30) - (l2 * l32)) + (l3 * l33)) * l27;
+            other.m[3] = -(((l2 * l34) - (l3 * l35)) + (l4 * l36)) * l27;
+            other.m[7] = (((l1 * l34) - (l3 * l37)) + (l4 * l38)) * l27;
+            other.m[11] = -(((l1 * l35) - (l2 * l37)) + (l4 * l39)) * l27;
+            other.m[15] = (((l1 * l36) - (l2 * l38)) + (l3 * l39)) * l27;
+
             return this;
         }
 
@@ -112,7 +120,8 @@ namespace BabylonExport.Entities
         /**
          * Update a Matrix with values composed by the passed scale (vector3), rotation (quaternion) and translation (vector3).  
          */
-        public static void ComposeToRef(BabylonVector3 scale, BabylonQuaternion rotation, BabylonVector3 translation, BabylonMatrix result) {
+        public static void ComposeToRef(BabylonVector3 scale, BabylonQuaternion rotation, BabylonVector3 translation, BabylonMatrix result)
+        {
             var matrix1 = new BabylonMatrix();
             BabylonMatrix.FromValuesToRef(scale.X, 0, 0, 0,
                 0, scale.Y, 0, 0,
@@ -125,18 +134,18 @@ namespace BabylonExport.Entities
 
             result.setTranslation(translation);
         }
-        
+
         /**
          * Returns a new indentity Matrix.  
          */
         public static BabylonMatrix Identity()
         {
             var matrix = new BabylonMatrix();
-             BabylonMatrix.FromValuesToRef(
-                1.0f, 0.0f, 0.0f, 0.0f,
-                0.0f, 1.0f, 0.0f, 0.0f,
-                0.0f, 0.0f, 1.0f, 0.0f,
-                0.0f, 0.0f, 0.0f, 1.0f, matrix);
+            BabylonMatrix.FromValuesToRef(
+               1.0f, 0.0f, 0.0f, 0.0f,
+               0.0f, 1.0f, 0.0f, 0.0f,
+               0.0f, 0.0f, 1.0f, 0.0f,
+               0.0f, 0.0f, 0.0f, 1.0f, matrix);
             return matrix;
         }
 
@@ -144,11 +153,16 @@ namespace BabylonExport.Entities
         {
             return a.multiply(b);
         }
+        public static BabylonVector3 operator * (BabylonVector3 a, BabylonMatrix b)
+        {
+           return b.TransformCoordinatesFromFloatsToRef(a.X, a.Y, a.Z, new BabylonVector3());
+        }
 
         /**
          * Returns a new Matrix set with the multiplication result of the current Matrix and the passed one.  
          */
-        public BabylonMatrix multiply(BabylonMatrix other) {
+        public BabylonMatrix multiply(BabylonMatrix other)
+        {
             var result = new BabylonMatrix();
             this.multiplyToRef(other, result);
             return result;
@@ -157,7 +171,8 @@ namespace BabylonExport.Entities
         /**
          * Sets the passed matrix "result" with the multiplication result of the current Matrix and the passed one.  
          */
-        public BabylonMatrix multiplyToRef(BabylonMatrix other, BabylonMatrix result) {
+        public BabylonMatrix multiplyToRef(BabylonMatrix other, BabylonMatrix result)
+        {
             this.multiplyToArray(other, result.m, 0);
             return this;
         }
@@ -201,25 +216,25 @@ namespace BabylonExport.Entities
             var om14 = other.m[14];
             var om15 = other.m[15];
 
-            result[offset] = tm0* om0 + tm1* om4 + tm2* om8 + tm3* om12;
-            result[offset + 1] = tm0* om1 + tm1* om5 + tm2* om9 + tm3* om13;
-            result[offset + 2] = tm0* om2 + tm1* om6 + tm2* om10 + tm3* om14;
-            result[offset + 3] = tm0* om3 + tm1* om7 + tm2* om11 + tm3* om15;
+            result[offset] = tm0 * om0 + tm1 * om4 + tm2 * om8 + tm3 * om12;
+            result[offset + 1] = tm0 * om1 + tm1 * om5 + tm2 * om9 + tm3 * om13;
+            result[offset + 2] = tm0 * om2 + tm1 * om6 + tm2 * om10 + tm3 * om14;
+            result[offset + 3] = tm0 * om3 + tm1 * om7 + tm2 * om11 + tm3 * om15;
 
-            result[offset + 4] = tm4* om0 + tm5* om4 + tm6* om8 + tm7* om12;
-            result[offset + 5] = tm4* om1 + tm5* om5 + tm6* om9 + tm7* om13;
-            result[offset + 6] = tm4* om2 + tm5* om6 + tm6* om10 + tm7* om14;
-            result[offset + 7] = tm4* om3 + tm5* om7 + tm6* om11 + tm7* om15;
+            result[offset + 4] = tm4 * om0 + tm5 * om4 + tm6 * om8 + tm7 * om12;
+            result[offset + 5] = tm4 * om1 + tm5 * om5 + tm6 * om9 + tm7 * om13;
+            result[offset + 6] = tm4 * om2 + tm5 * om6 + tm6 * om10 + tm7 * om14;
+            result[offset + 7] = tm4 * om3 + tm5 * om7 + tm6 * om11 + tm7 * om15;
 
-            result[offset + 8] = tm8* om0 + tm9* om4 + tm10* om8 + tm11* om12;
-            result[offset + 9] = tm8* om1 + tm9* om5 + tm10* om9 + tm11* om13;
-            result[offset + 10] = tm8* om2 + tm9* om6 + tm10* om10 + tm11* om14;
-            result[offset + 11] = tm8* om3 + tm9* om7 + tm10* om11 + tm11* om15;
+            result[offset + 8] = tm8 * om0 + tm9 * om4 + tm10 * om8 + tm11 * om12;
+            result[offset + 9] = tm8 * om1 + tm9 * om5 + tm10 * om9 + tm11 * om13;
+            result[offset + 10] = tm8 * om2 + tm9 * om6 + tm10 * om10 + tm11 * om14;
+            result[offset + 11] = tm8 * om3 + tm9 * om7 + tm10 * om11 + tm11 * om15;
 
-            result[offset + 12] = tm12* om0 + tm13* om4 + tm14* om8 + tm15* om12;
-            result[offset + 13] = tm12* om1 + tm13* om5 + tm14* om9 + tm15* om13;
-            result[offset + 14] = tm12* om2 + tm13* om6 + tm14* om10 + tm15* om14;
-            result[offset + 15] = tm12* om3 + tm13* om7 + tm14* om11 + tm15* om15;
+            result[offset + 12] = tm12 * om0 + tm13 * om4 + tm14 * om8 + tm15 * om12;
+            result[offset + 13] = tm12 * om1 + tm13 * om5 + tm14 * om9 + tm15 * om13;
+            result[offset + 14] = tm12 * om2 + tm13 * om6 + tm14 * om10 + tm15 * om14;
+            result[offset + 15] = tm12 * om3 + tm13 * om7 + tm14 * om11 + tm15 * om15;
             return this;
         }
 
@@ -227,11 +242,12 @@ namespace BabylonExport.Entities
          * Inserts the translation vector in the current Matrix.  
          * Returns the updated Matrix.  
          */
-        public BabylonMatrix setTranslation(BabylonVector3 vector3) {
+        public BabylonMatrix setTranslation(BabylonVector3 vector3)
+        {
             this.m[12] = vector3.X;
             this.m[13] = vector3.Y;
             this.m[14] = vector3.Z;
-            
+
             return this;
         }
 
@@ -252,11 +268,13 @@ namespace BabylonExport.Entities
             scale.Y = (float)Math.Sqrt(this.m[4] * this.m[4] + this.m[5] * this.m[5] + this.m[6] * this.m[6]);
             scale.Z = (float)Math.Sqrt(this.m[8] * this.m[8] + this.m[9] * this.m[9] + this.m[10] * this.m[10]);
 
-            if (this.determinant() <= 0) {
+            if (this.determinant() <= 0)
+            {
                 scale.Y *= -1;
             }
 
-            if (scale.X == 0 || scale.Y == 0 || scale.Z == 0) {
+            if (scale.X == 0 || scale.Y == 0 || scale.Z == 0)
+            {
                 rotation.X = 0;
                 rotation.Y = 0;
                 rotation.Z = 0;
@@ -319,5 +337,17 @@ namespace BabylonExport.Entities
             result.m[14] = initialM43;
             result.m[15] = initialM44;
         }
-}
+
+        public BabylonVector3 TransformCoordinatesFromFloatsToRef(float x, float y, float z, BabylonVector3 result)
+        {
+            var rx = x * m[0] + y * m[4] + z * m[8] + m[12];
+            var ry = x * m[1] + y * m[5] + z * m[9] + m[13];
+            var rz = x * m[2] + y * m[6] + z * m[10] + m[14];
+
+            result.X = rx;
+            result.Y = ry;
+            result.Z = rz;
+            return result;
+        }
+    }
 }

--- a/SharedProjects/BabylonExport.Entities/BabylonMatrix.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMatrix.cs
@@ -31,6 +31,15 @@ namespace BabylonExport.Entities
             var q = BabylonQuaternion.FromEulerAngles(0, 0, rad).toRotationMatrix(rotate);
             return rotate;
         }
+        public static BabylonMatrix Scale(BabylonVector3 scale)
+        {
+            var result = Identity();
+            BabylonMatrix.FromValuesToRef(scale.X, 0, 0, 0,
+                            0, scale.Y, 0, 0,
+                            0, 0, scale.Z, 0,
+                            0, 0, 0, 1, result);
+            return result;
+        }
         /**
          * Inverts in place the Matrix.  
          * Returns the Matrix inverted.  

--- a/SharedProjects/BabylonExport.Entities/BabylonVector3.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonVector3.cs
@@ -51,7 +51,10 @@ namespace BabylonExport.Entities
         {
             return new BabylonVector3 { X = a.X * b, Y = a.Y * b, Z = a.Z * b };
         }
-
+        public static BabylonVector3 operator -(BabylonVector3 a)
+        {
+            return new BabylonVector3 { X = -a.X , Y = -a.Y , Z = -a.Z};
+        }
         public enum EulerRotationOrder
         {
             XYZ,

--- a/SharedProjects/Utilities/MathUtilities.cs
+++ b/SharedProjects/Utilities/MathUtilities.cs
@@ -82,18 +82,13 @@ namespace Utilities
 
 
         /**
-         * Computes a texture transform matrix with a pre-transformation
+         * Computes a texture transform matrix with a pre-transformation 
          */
         public static BabylonMatrix ComputeTextureTransformMatrix(BabylonVector3 pivotCenter, BabylonVector3 offset, BabylonQuaternion rotation, BabylonVector3 scale)
         {
-            var dOffset = new BabylonVector3();
-            var dRotation = new BabylonQuaternion();
-            var dScale = new BabylonVector3();
-            offset.X *= scale.X;
-            offset.Y *= scale.Y;
-            offset.Z *= 0;
-
-            var transformMatrix = BabylonMatrix.Translation(new BabylonVector3(-pivotCenter.X, -pivotCenter.Y, 0)).multiply(BabylonMatrix.Compose(scale, rotation, offset)).multiply(BabylonMatrix.Translation(pivotCenter));
+            var transformMatrix = BabylonMatrix.Translation(new BabylonVector3(-pivotCenter.X, -pivotCenter.Y, 0))
+                                               .multiply(BabylonMatrix.Compose(scale, rotation, offset))
+                                               .multiply(BabylonMatrix.Translation(pivotCenter));
             return transformMatrix;
         }
     }


### PR DESCRIPTION
Giving the Max file into the following archive,
[KHR_Texture_transform.zip](https://github.com/BabylonJS/Exporters/files/7149511/KHR_Texture_transform.zip)
result are now coherent as you can see in .babylon and .gltf attached files.
Fix #1001.
MAX
![image](https://user-images.githubusercontent.com/22658224/132986274-ded72ee9-6574-4dd3-bd4e-41064a9149e1.png)
BABYLON
![image](https://user-images.githubusercontent.com/22658224/132986305-c0366132-c54e-4260-9098-87417f2a2ed0.png)
GLTF
![image](https://user-images.githubusercontent.com/22658224/132986330-a000d543-7a66-47b8-ab68-145e8355f3b8.png)

