### PR TITLE
Fix camera animation rotation issues

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -484,14 +484,13 @@ namespace Max2Babylon
 
         private void OptimizeAnimations(List<BabylonAnimationKey> keys, bool removeLinearAnimationKeys)
         {
-            for (int ixFirst = keys.Count - 3; ixFirst >= 0; --ixFirst)
+            // 2 frames can not beeing optimized
+            if (keys.Count > 2)
             {
-                while (keys.Count - ixFirst >= 3)
+                // take the frame by block of 3, descending
+                for (int ixFirst = keys.Count - 3; ixFirst >= 0; --ixFirst)
                 {
-                    if (!RemoveAnimationKey(keys, ixFirst, removeLinearAnimationKeys))
-                    {
-                        break;
-                    }
+                    RemoveAnimationKey(keys, ixFirst, removeLinearAnimationKeys);
                 }
             }
         }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Camera.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Camera.cs
@@ -177,7 +177,7 @@ namespace Max2Babylon
                     animationRotationQuaternion = animations.Find(animation => animation.property.Equals("rotationQuaternion"));
                     if (animationRotationQuaternion != null)
                     {
-                        foreach (BabylonAnimationKey key in animationRotationQuaternion.keys)
+                        foreach (BabylonAnimationKey key in animationRotationQuaternion.keysFull)
                         {
                             key.values = FixCameraQuaternion(key.values, angle);
                         }
@@ -191,7 +191,7 @@ namespace Max2Babylon
                     animationRotationQuaternion = extraAnimations.Find(animation => animation.property.Equals("rotationQuaternion"));
                     if (animationRotationQuaternion != null)
                     {
-                        foreach (BabylonAnimationKey key in animationRotationQuaternion.keys)
+                        foreach (BabylonAnimationKey key in animationRotationQuaternion.keysFull)
                         {
                             key.values = FixCameraQuaternion(key.values, angle);
                         }
@@ -228,7 +228,7 @@ namespace Max2Babylon
                         BabylonAnimation animationPosition = animations.Find(animation => animation.property.Equals("position"));
                         if (animationPosition != null)
                         {
-                            foreach (BabylonAnimationKey key in animationPosition.keys)
+                            foreach (BabylonAnimationKey key in animationPosition.keysFull)
                             {
                                 key.values = new float[] { key.values[0], key.values[2], -key.values[1] };
                             }
@@ -238,7 +238,7 @@ namespace Max2Babylon
                         animationRotationQuaternion = animations.Find(animation => animation.property.Equals("rotationQuaternion"));
                         if (animationRotationQuaternion != null)
                         {
-                            foreach (BabylonAnimationKey key in animationRotationQuaternion.keys)
+                            foreach (BabylonAnimationKey key in animationRotationQuaternion.keysFull)
                             {
                                 key.values = FixChildQuaternion(key.values, angle);
                             }
@@ -247,8 +247,6 @@ namespace Max2Babylon
                 }
             }
         }
-
-
 
         private BabylonQuaternion FixCameraQuaternion(BabylonNode node, double angle)
         {

--- a/3ds Max/Max2Babylon/Tools/Tools.cs
+++ b/3ds Max/Max2Babylon/Tools/Tools.cs
@@ -430,10 +430,30 @@ namespace Max2Babylon
             {
                 return false;
             }
-
-            return !value.Where((t, i) => Math.Abs(t - other[i]) > Epsilon).Any();
+            for(int i=0; i!= value.Length; i++)
+            {
+                if( value[i] != other[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
-
+        public static bool IsAlmostEqualTo(this float[] value, float[] other, float epsilon = Epsilon)
+        {
+            if (value.Length != other.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i != value.Length; i++)
+            {
+                if (Math.Abs(value[i] - other[i]) > Epsilon)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
         public static float[] ToArray(this IMatrix3 value)
         {
 


### PR DESCRIPTION
fix  #1003.
the bug was located into FixCamera methods where the transformation was applied to animation.keys which is a subset of animation.fullkeys. Then only a part of the keys was updated. By then reaching the AnimationGroup, the process relies on animation.fullkeys which was then no longer consistent. Note that animation optimization is done twice, one time when exporting the node and one time when exporting animation group.

