### PR TITLE
unset selected flag during scene initialize

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -1070,9 +1070,6 @@ namespace Max2Babylon
 
             Action<Autodesk.Max.IGameObject.ObjectTypes> addMaxRootNodes = delegate (Autodesk.Max.IGameObject.ObjectTypes type)
             {
-                IIGameNode n = maxGameScene.GetTopLevelNode(0);
-                n = maxGameScene.GetTopLevelNode(1);
-                n = maxGameScene.GetTopLevelNode(2);
                 ITab<IIGameNode> maxGameNodesOfType = maxGameScene.GetIGameNodeByType(type);
                 var tmp = TabToList(maxGameNodesOfType);
                 // filter on selected here to optimize performance for complexes scenes, and keep the hierarchy consistent.


### PR DESCRIPTION
fix #1008 .
When `Export selected Only` options is set, the behavior was to set the flag "selected" during scene initialize. However an Autodesk API bug, or undocumented behavior, prevent child nodes to be exported during the initialization.
On other hand, we can NOT process all the meshes. see #998.
So finally, the solution is to unset the flag, and select only the branch of the hierarch where node are selected.