### PR TITLE
3DSMax exporter to avoid negative frame index for animation

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -303,10 +303,11 @@ namespace Max2Babylon
 #else
                 var gameKey = gameKeyTab[new IntPtr(indexKey)];
 #endif
-
+                var f = gameKey.T / Loader.Global.TicksPerFrame;
                 var key = new BabylonAnimationKey()
                 {
-                    frame = gameKey.T / Loader.Global.TicksPerFrame,
+                    // ensure the frame if not negative.
+                    frame = f<0?0:f,
                     values = extractValueFunc(gameKey)
                 };
                 keys.Add(key);

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -303,11 +303,10 @@ namespace Max2Babylon
 #else
                 var gameKey = gameKeyTab[new IntPtr(indexKey)];
 #endif
-                var f = gameKey.T / Loader.Global.TicksPerFrame;
                 var key = new BabylonAnimationKey()
                 {
                     // ensure the frame if not negative.
-                    frame = f<0?0:f,
+                    frame = gameKey.T / Loader.Global.TicksPerFrame,
                     values = extractValueFunc(gameKey)
                 };
                 keys.Add(key);

--- a/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
@@ -8,8 +8,11 @@ namespace BabylonExport.Entities
     [DataContract]
     public class BabylonAnimationKey : IComparable<BabylonAnimationKey>, ICloneable
     {
+        private float _f;
+
         [DataMember]
-        public float frame { get; set; }
+        // guard for negative value.
+        public float frame { get => _f; set => _f = value < 0 ? 0 : value; }
 
         [DataMember]
         public float[] values { get; set; }


### PR DESCRIPTION
When 3DSMax user put a negative frame time into Animation, the exporter did not export the this animation correctly. We put a simple guard to limit the frame index to zero and avoid negative values. fix #1013.