### PR TITLE
Save bone as relevant when single

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -94,15 +94,18 @@ namespace Max2Babylon
             }
 
             // Babylon format assumes skeleton root is at origin, add any additional node parents from the lowest common ancestor to the scene root to the skeleton hierarchy.
-            while (lowestCommonAncestor.NodeParent != null)
+            allHierarchyNodes.Add(lowestCommonAncestor);
+            if (lowestCommonAncestor.NodeParent != null)
             {
-                lowestCommonAncestor = lowestCommonAncestor.NodeParent;
-                allHierarchyNodes.Add(lowestCommonAncestor);
-            }
+                do {
+                    lowestCommonAncestor = lowestCommonAncestor.NodeParent;
+                    allHierarchyNodes.Add(lowestCommonAncestor);
+                } while (lowestCommonAncestor.NodeParent != null) ;
+            } 
 
             // starting from the root, sort the nodes by depth first (add the children before the siblings)
             List<IIGameNode> sorted = new List<IIGameNode>();
-            Stack<IIGameNode> siblings = new Stack<IIGameNode>();   // keep the siblings in a LIFO list to add them after the children
+            Stack<IIGameNode> siblings = new Stack<IIGameNode>();  // keep the siblings in a LIFO list to add them after the children
             siblings.Push(lowestCommonAncestor);
 
             // add the skeletonroot:


### PR DESCRIPTION
Current version is NOT taking bone in account when single. This NOT fix the entire skeleton issues, but at least let people using a single bone to animate GLTF
see [this ](https://forum.babylonjs.com/t/skeleton-animation-in-3ds-max-will-not-export-to-glb/26121/9) forum post and also [this](https://forum.babylonjs.com/t/mesh-with-1-bone-from-3dsmax-causes-blank-scene/25390/9).