### PR TITLE
Skin hierarchy

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -236,7 +236,7 @@ namespace Max2Babylon
             IGMatrix skinInitPoseMatrix = Loader.Global.GMatrix.Create(Loader.Global.Matrix3.Create(true));
             List<int> boneIds = null;
             int maxNbBones = 0;
-            List<IIGameNode> skinnedBones = GetSkinnedBones(skin);
+            List<IIGameNode> skinnedBones = GetSkinnedBones(skin).Item1;
             if (isSkinned && skinnedBones.Count > 0)  // if the mesh has a skin with at least one bone
             {
                 var skinAlreadyStored = skins.Find(_skin => IsSkinEqualTo(_skin, skin));

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -183,6 +183,9 @@ namespace Max2Babylon
             return commonAncestor;
         }
 
+        // fetch recursively the childrens to see if any of it, reference the skin.
+        // the fetch stop at the first node passing the test.
+        // down search is deep first.
         private bool HasSkinAsChild(IIGameNode node, IIGameSkin skin)
         {
             if( skin == null)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -50,13 +50,13 @@ namespace Max2Babylon
         /// <returns>
         /// All nodes needed for the skeleton hierarchy
         /// </returns>
-        private Dictionary<IIGameSkin, (List<IIGameNode>, float[])> relevantNodesBySkin = new Dictionary<IIGameSkin, (List<IIGameNode>,float[])>();
-        private (List<IIGameNode>, float[]) GetSkinnedBones(IIGameSkin skin)
+        private Dictionary<IIGameSkin, Tuple<List<IIGameNode>, float[]>> relevantNodesBySkin = new Dictionary<IIGameSkin, Tuple<List<IIGameNode>, float[]>>();
+        private Tuple<List<IIGameNode>, float[]> GetSkinnedBones(IIGameSkin skin)
         {
 
             if (skin == null)
             {
-                return (new List<IIGameNode>(),null);
+                return new Tuple<List<IIGameNode>, float[]>(new List<IIGameNode>(),null);
             }
 
             int logRank = 2;
@@ -72,14 +72,14 @@ namespace Max2Babylon
             if (bones.Count == 0)
             {
                 RaiseWarning("Skin has no bones.", logRank);
-                return (new List<IIGameNode>(), null);
+                return new Tuple<List<IIGameNode>, float[]>(new List<IIGameNode>(), null);
             }
 
             if (bones.Contains(null))
             {
                 RaiseError("Skin has bones that are outside of the exported hierarchy.", logRank);
                 RaiseError("The skin cannot be exported", logRank);
-                return (new List<IIGameNode>(), null);
+                return new Tuple<List<IIGameNode>, float[]>(new List<IIGameNode>(), null);
             }
 
             List<IIGameNode> allHierarchyNodes = null;
@@ -90,7 +90,7 @@ namespace Max2Babylon
                 RaiseError($"More than one root node for the skin. The skeleton bones need to be part of the same hierarchy.", logRank);
                 RaiseError($"The skin cannot be exported", logRank);
 
-                return (new List<IIGameNode>(), null);
+                return new Tuple<List<IIGameNode>, float[]>(new List<IIGameNode>(), null);
             }
 
             allHierarchyNodes.Add(lowestCommonAncestor);
@@ -146,7 +146,7 @@ namespace Max2Babylon
                     }
                 }
             }
-            var result = (sorted, rootTransformation);
+            var result = new Tuple<List<IIGameNode>, float[]>(sorted, rootTransformation);
             
             relevantNodesBySkin.Add(skin, result);   // Stock the result for optimization
 
@@ -356,7 +356,7 @@ namespace Max2Babylon
         {
             List<BabylonBone> bones = new List<BabylonBone>();
             List<int> nodeIndices = GetNodeIndices(skin);
-            (List<IIGameNode>,float[]) revelantNodes = GetSkinnedBones(skin);
+            Tuple<List<IIGameNode>,float[]> revelantNodes = GetSkinnedBones(skin);
             
             var rootMatrix = revelantNodes.Item2;
 


### PR DESCRIPTION
Add search down hierarchy to identify the presence of the skinned mesh and consequently select different Transformation matrix for the skeleton root (World, Local or Identity).
Before this only World and Identity were considered.
For BabylonJS, the Skeleton root cannot share a common ancestor with the mesh it own the skin, otherwize, the transformation is applied twice.
Therefore, Max is highly permissive regarding this point and allow ANY mesh to be a bone or part of the hierachy.
This PR fix this particular case. 
