### PR TITLE
Update root bone animation matrix

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Animation.cs
@@ -3,6 +3,7 @@ using BabylonExport.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Utilities;
 
 namespace Max2Babylon
 {

--- a/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
@@ -9,13 +9,23 @@ namespace BabylonExport.Entities
     public class BabylonAnimationKey : IComparable<BabylonAnimationKey>, ICloneable
     {
         private float _f;
+        private float[] _values;
 
         [DataMember]
         // guard for negative value.
         public float frame { get => _f; set => _f = value < 0 ? 0 : value; }
 
         [DataMember]
-        public float[] values { get; set; }
+        public float[] values {
+            get
+            {
+                return _values;
+            }
+            set
+            {
+                _values = MathUtilities.CleanEpsilon(value);
+            } 
+        }
 
         public object Clone()
         {

--- a/SharedProjects/BabylonExport.Entities/BabylonMatrix.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMatrix.cs
@@ -1,4 +1,5 @@
 using System;
+using Utilities;
 
 namespace BabylonExport.Entities
 {
@@ -358,5 +359,6 @@ namespace BabylonExport.Entities
             result.Z = rz;
             return result;
         }
+
     }
 }

--- a/SharedProjects/Utilities/MathUtilities.cs
+++ b/SharedProjects/Utilities/MathUtilities.cs
@@ -91,5 +91,16 @@ namespace Utilities
                                                .multiply(BabylonMatrix.Translation(pivotCenter));
             return transformMatrix;
         }
+
+
+        public static float[] CleanEpsilon(float[] data)
+        {
+            for (int i = 0; i != data.Length; i++)
+            {
+                data[i] = Math.Abs(data[i]) <= MathUtilities.Epsilon ? 0 : data[i];
+                data[i] = Math.Abs(1.0 - data[i]) <= MathUtilities.Epsilon ? 1 : data[i];
+            }
+            return data;
+        }
     }
 }


### PR DESCRIPTION
Update root bone animation matrix according the one set into the bone.
The previous PR changed the bone matrix of the root, as appropriate for the hierarchy. However, we missed updating the animation matrix accordingly.