### PR TITLE
Add an additional root node when only one join into skeleton

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -1181,6 +1181,9 @@ namespace Max2Babylon
                 float[] weight = new float[4] { 0, 0, 0, 0 };
                 int[] bone = new int[4] { 0, 0, 0, 0 };
                 var nbBones = skin.GetNumberOfBones(vertexIndex);
+                // Babylon, nor GLTF do not support single bone skeleton, we may add a root node  with no transform.
+                // this is echoing the process into BabylonExporter.Skeleton ExportBones(Skin)
+                var offset = nbBones == 1 ? 1 : 0;
 
                 int currentVtxBone = 0;
                 int currentSkinBone = 0;
@@ -1192,7 +1195,7 @@ namespace Max2Babylon
                     if (boneWeight <= 0)
                         continue;
 
-                    bone[currentVtxBone] = boneIds.IndexOf(skin.GetIGameBone(vertexIndex, currentSkinBone).NodeID);
+                    bone[currentVtxBone] = boneIds.IndexOf(skin.GetIGameBone(vertexIndex, currentSkinBone).NodeID) + offset; // add optional offset
                     weight[currentVtxBone] = skin.GetWeight(vertexIndex, currentSkinBone);
                     ++currentVtxBone;
                 }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -424,6 +424,28 @@ namespace Max2Babylon
                 bones.Add(bone);
             }
 
+            // Babylon, nor GLTF do not support single bone skeleton, we may add a root node  with no transform.
+            if( bones.Count == 1)
+            {
+                var root  = new BabylonBone()
+                {
+                    id = Guid.NewGuid().ToString(),
+                    parentNodeId = null,
+                    name = "root-bone-added",
+                    index = 0,
+                    parentBoneIndex = -1,
+                    matrix = BabylonMatrix.Identity().m
+                };
+
+                var bone = bones[0];
+                bone.parentNodeId = root.id;
+                bone.index = 1;
+                bone.parentBoneIndex = 0;
+
+                bones.Insert(0, root);
+            }
+
+            // finally return the bones.
             return bones.ToArray();
         }
     }


### PR DESCRIPTION
Both Babylon and GLTF does need a root node for the skeleton, which mean that the minimum of join into a skeleton is 2. One of the reason is we need a fallback to address vertex who does not hold any join influence ( weight 1,0,0,0 to join 0 ).  
3DSMax is more permissive and let user define a single join skin. 
This PR fix this issue, adding a root in this case. 