### PR TITLE
Remove negative key frame guard at babylon level

### DIFF
--- a/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonAnimationKey.cs
@@ -12,8 +12,7 @@ namespace BabylonExport.Entities
         private float[] _values;
 
         [DataMember]
-        // guard for negative value.
-        public float frame { get => _f; set => _f = value < 0 ? 0 : value; }
+        public float frame { get => _f; set => _f = value; }
 
         [DataMember]
         public float[] values {


### PR DESCRIPTION
according [this ](https://forum.babylonjs.com/t/maya-to-babylonjs-gltf-validation-error/28285/7)Forum thread,  for gltf offset the negative key frame instead of trim at zero. 