### PR TITLE
Change way to load bitmap from file

### DIFF
--- a/SharedProjects/Utilities/Texture/TextureUtilities.cs
+++ b/SharedProjects/Utilities/Texture/TextureUtilities.cs
@@ -117,7 +117,6 @@ namespace Utilities
                         case ".tiff":
                             {
                                 return (Bitmap)_imageConverter.ConvertFrom(File.ReadAllBytes(absolutePath));
-                                // return new Bitmap(absolutePath).Clone;
                             }
                         default:
                             logger.RaiseError(string.Format("Format of texture {0} is not supported by the exporter. Consider using a standard image format like jpg or png.", Path.GetFileName(absolutePath)), 3);

--- a/SharedProjects/Utilities/Texture/TextureUtilities.cs
+++ b/SharedProjects/Utilities/Texture/TextureUtilities.cs
@@ -89,6 +89,7 @@ namespace Utilities
             return haveSameDimensions;
         }
 
+        private static readonly ImageConverter _imageConverter = new ImageConverter();
         public static Bitmap LoadTexture(string absolutePath, ILoggingProvider logger)
         {
             if (File.Exists(absolutePath))
@@ -114,7 +115,10 @@ namespace Utilities
                         case ".png":
                         case ".tif":
                         case ".tiff":
-                            return new Bitmap(absolutePath);
+                            {
+                                return (Bitmap)_imageConverter.ConvertFrom(File.ReadAllBytes(absolutePath));
+                                // return new Bitmap(absolutePath).Clone;
+                            }
                         default:
                             logger.RaiseError(string.Format("Format of texture {0} is not supported by the exporter. Consider using a standard image format like jpg or png.", Path.GetFileName(absolutePath)), 3);
                             return null;


### PR DESCRIPTION
using common way of new Bitmap(path) is known as lock the ressource until disposed.
However, none of the object are disposed at the end of the export session (this might be another refactoring need). 
The solution is to change the way we load the image and use ImageConverter from byte [] instead of direct Bitmap linked with the underlying file.

- Pro is we are doing the change at one place only.
- Cons is we are still waste memory.

fix #1033 