### PR TITLE
remove needInitialSkinMatrix boolean set

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Skeleton.cs
@@ -351,8 +351,7 @@ namespace Max2Babylon
             {
                 id = skinIndex,
                 name = name,
-                bones = ExportBones(skin),
-                needInitialSkinMatrix = true
+                bones = ExportBones(skin)
             };
 
             babylonScene.SkeletonsList.Add(babylonSkeleton);

--- a/Maya/Exporter/BabylonExporter.Skeleton.cs
+++ b/Maya/Exporter/BabylonExporter.Skeleton.cs
@@ -38,8 +38,7 @@ namespace Maya2Babylon
             BabylonSkeleton babylonSkeleton = new BabylonSkeleton {
                 id = skinIndex,
                 name = name,
-                bones = ExportBones(skin),
-                needInitialSkinMatrix = true
+                bones = ExportBones(skin)
             };
             
             babylonScene.SkeletonsList.Add(babylonSkeleton);


### PR DESCRIPTION
According to [this ](https://forum.babylonjs.com/t/meshes-with-skeletons-that-have-needinitialskinmatrix-true-crash-when-cloned/28247/9)forum thread, we remove the needInitialSkinMatrix  it was explicitely set to true.
Conducted test over few scene did not conclude to any regression so far.