### PR TITLE
Maya test SkinCluster and Set to find Blend into the graph

### DIFF
--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -1204,7 +1204,7 @@ namespace Maya2Babylon
                 MObject source = connection.source.node;
                 if (source != null)
                 {
-                    if (source.hasFn(MFn.Type.kSet))
+                    if (source.hasFn(MFn.Type.kSet) || source.hasFn(MFn.Type.kSkinClusterFilter))
                     {
                         blendShapeDeformers.AddRange(GetBlendShapeSub(source));
                     }


### PR DESCRIPTION
According to [this](https://forum.babylonjs.com/t/cannot-export-mesh-to-glb-with-both-morph-targets-and-skinning-in-maya-2022/28309/4) thread, modify the search to allow the exporter to search the graph down the skin.