### PR TITLE
3DS Max Add autoAnimate related properties to Babylon MorphTarget Manager

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -599,6 +599,8 @@ namespace Max2Babylon
                                     if (animations.Count > 0)
                                     {
                                         babylonMorphTarget.animations = animations.ToArray();
+                                        babylonMorphTarget.autoAnimate = true;
+                                        babylonMorphTarget.autoAnimateLoop = true;
                                     }
                                 }
                             }

--- a/SharedProjects/BabylonExport.Entities/BabylonMorphTarget.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMorphTarget.cs
@@ -25,5 +25,17 @@ namespace BabylonExport.Entities
 
         [DataMember(EmitDefaultValue = false)]
         public BabylonAnimation[] animations { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public bool autoAnimate { get; set; }
+        
+        [DataMember(EmitDefaultValue = false)]
+        public bool autoAnimateLoop { get; set; }
+        
+        [DataMember(EmitDefaultValue = false)]
+        public int? autoAnimateFrom { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public int? autoAnimateTo { get; set; }
     }
 }


### PR DESCRIPTION
According to [this ](https://forum.babylonjs.com/t/morphtargetmanagers-not-playing-animation-into-sandbox/27188/14) thread, update the code to leverage MorphManager auto-animation behavior of the Babylon SandBox (for Babylon format only)