### PR TITLE
Fix metal-rough factor when no map but metal-rough factor not 0

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -705,8 +705,8 @@ namespace Max2Babylon
                         // Change the factor to zero if combining partial channel to avoid issue (in case of image compression).
                         // ie - if no metallic map, then b MUSt be fully black. However channel of jpeg MAY not beeing fully black 
                         // cause of the compression algorithm. Keeping MetallicFactor to 1 will make visible artifact onto texture. So set to Zero instead.
-                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null ? 1.0f : 0.0f;
-                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null ? 1.0f : 0.0f;
+                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null || (metallicTexmap == null && babylonMaterial.metallic != 0) ? 1.0f : 0.0f;
+                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null || (roughnessTexmap == null && babylonMaterial.roughness != 0) ? 1.0f : 0.0f;
                     }
                 }
             }
@@ -959,8 +959,8 @@ namespace Max2Babylon
                         // Change the factor to zero if combining partial channel to avoid issue (in case of image compression).
                         // ie - if no metallic map, then b MUSt be fully black. However channel of jpeg MAY not beeing fully black 
                         // cause of the compression algorithm. Keeping MetallicFactor to 1 will make visible artifact onto texture. So set to Zero instead.
-                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null ? 1.0f : 0.0f;
-                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null ? 1.0f : 0.0f;
+                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null || (metallicTexmap == null && babylonMaterial.metallic != 0) ? 1.0f : 0.0f;
+                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null || (roughnessTexmap == null && babylonMaterial.roughness != 0) ? 1.0f : 0.0f;
                     }
                 }
             }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -705,8 +705,8 @@ namespace Max2Babylon
                         // Change the factor to zero if combining partial channel to avoid issue (in case of image compression).
                         // ie - if no metallic map, then b MUSt be fully black. However channel of jpeg MAY not beeing fully black 
                         // cause of the compression algorithm. Keeping MetallicFactor to 1 will make visible artifact onto texture. So set to Zero instead.
-                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null || (metallicTexmap == null && babylonMaterial.metallic != 0) ? 1.0f : 0.0f;
-                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null || (roughnessTexmap == null && babylonMaterial.roughness != 0) ? 1.0f : 0.0f;
+                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null || babylonMaterial.metallic != 0 ? 1.0f : 0.0f;
+                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null || babylonMaterial.roughness != 0 ? 1.0f : 0.0f;
                     }
                 }
             }
@@ -959,8 +959,8 @@ namespace Max2Babylon
                         // Change the factor to zero if combining partial channel to avoid issue (in case of image compression).
                         // ie - if no metallic map, then b MUSt be fully black. However channel of jpeg MAY not beeing fully black 
                         // cause of the compression algorithm. Keeping MetallicFactor to 1 will make visible artifact onto texture. So set to Zero instead.
-                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null || (metallicTexmap == null && babylonMaterial.metallic != 0) ? 1.0f : 0.0f;
-                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null || (roughnessTexmap == null && babylonMaterial.roughness != 0) ? 1.0f : 0.0f;
+                        babylonMaterial.metallic = areTexturesAlreadyMerged || metallicTexmap != null || babylonMaterial.metallic != 0 ? 1.0f : 0.0f;
+                        babylonMaterial.roughness = areTexturesAlreadyMerged || roughnessTexmap != null || babylonMaterial.roughness != 0 ? 1.0f : 0.0f;
                     }
                 }
             }


### PR DESCRIPTION
This fixes a bug that occurs when there is no metal or roughness map but a metal or roughness factor other than 0. 

**Steps to reproduce the bug:**

1. Create a Physical Material
2. Link a metallic texture to the Metalness Map slot
3. Set Roughness factor to 0.8
4. Export

**Expected behaviour**
The exporter creates and merges a texture with color value 0.8 (204) in G-channel into the ORM/MR texture and sets the metalness and roughness factors to 1 because they are often used as texture weights (see e.g. Babylon.js Sandbox).

**Actual behaviour**
The exporter creates a correct ORM/MR texture with the given roughness value of 0.8 (204) in G-channel but sets the roughness factor to 0. Therefore, the roughness values in G-channel are completely ignored. The same happens exactly the other way around with a material-wide metalness factor and a roughness texture assigned to the Roughness Map slot.

**Further information**
The bug seems to be related to an older fix described here https://github.com/BabylonJS/Exporters/pull/909.
My proposed fix consists of a further check if a metallic or roughness map is given and the metalness or roughness factor is not 0. 