### PR TITLE
Correct Bump Level property access for max 2023

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -695,7 +695,11 @@ namespace Max2Babylon
                         babylonMaterial.occlusionTexture = ExportTexture(ambientOcclusionTexmap, babylonScene);
                     }
 
+#if MAX2023
+                    var normalMapAmount = propertyContainer.GetFloatProperty("bump_map_amt");
+#else
                     var normalMapAmount = propertyContainer.GetFloatProperty(91);
+#endif
                     babylonMaterial.normalTexture = ExportPBRTexture(materialNode, 30, babylonScene, normalMapAmount);
 
                     babylonMaterial.emissiveTexture = ExportPBRTexture(materialNode, 17, babylonScene);


### PR DESCRIPTION
Due to UI change, properties indices are not longer always valid for Material. 
This PR is a quick fix for bump level, but it MUST be extended for all the property that has been to be addressed by Name instead of index (which unlikely change between version).