### PR TITLE
Remove mandatory Maya rename operation 

### DIFF
--- a/Maya/Maya2Babylon2017.csproj
+++ b/Maya/Maya2Babylon2017.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Maya2Babylon</RootNamespace>
-    <AssemblyName>Maya2Babylon</AssemblyName>
+    <AssemblyName>Maya2Babylon.nll</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -160,12 +160,28 @@
   <Import Project="..\SharedProjects\Babylon2GLTF\Babylon2GLTF.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
+    <PostBuildEvent>
+setlocal enabledelayedexpansion
+
+SET configurationName=$(ConfigurationName)
+ECHO %25configurationName%25
+
+if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
 if not exist "$(SolutionDir)assemblies\2017-2018" mkdir "$(SolutionDir)assemblies\2017-2018"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2017-2018\"
-del "$(SolutionDir)assemblies\2017-2018\$(TargetName).dll"
-copy "$(TargetPath)" "$(SolutionDir)assemblies\2017-2018\$(TargetName).nll.dll"
-if exist "D:\Programmes\Autodesk\Maya2018\bin\plug-ins\" copy "$(SolutionDir)assemblies\2017-2018\*.dll" "D:\Programmes\Autodesk\Maya2018\bin\plug-ins\"
-if exist "C:\Program Files\Autodesk\Maya2018\bin\plug-ins\" copy "$(SolutionDir)assemblies\2017-2018\*.dll" "C:\Program Files\Autodesk\Maya2018\bin\plug-ins\"</PostBuildEvent>
+if exist "D:\Programmes\Autodesk\Maya2017-2018\bin\plug-ins\" copy "$(SolutionDir)assemblies\2017-2018\*.dll" "D:\Programmes\Autodesk\Maya2017-2018\bin\plug-ins\"
+if exist "C:\Program Files\Autodesk\Maya2017-2018\bin\plug-ins\" copy "$(SolutionDir)assemblies\2017-2018\*.dll" "C:\Program Files\Autodesk\Maya2017-2018\bin\plug-ins\"
+
+IF "%25configurationName%25"=="Debug" GOTO DebugOnMaya
+GOTO Close
+
+:DebugOnMaya
+if exist "C:\Program Files\Autodesk\Maya2018\bin\maya.exe" START /d "C:\Program Files\Autodesk\Maya2018\bin" maya.exe
+GOTO Close
+
+:Close
+PAUSE
+EXIT
+</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Maya/Maya2Babylon2019.csproj
+++ b/Maya/Maya2Babylon2019.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Maya2Babylon</RootNamespace>
-    <AssemblyName>Maya2Babylon</AssemblyName>
+    <AssemblyName>Maya2Babylon.nll</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -171,8 +171,6 @@ ECHO %25configurationName%25
 if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
 if not exist "$(SolutionDir)assemblies\2019" mkdir "$(SolutionDir)assemblies\2019"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2019\"
-del "$(SolutionDir)assemblies\2019\$(TargetName).dll"
-copy "$(TargetPath)" "$(SolutionDir)assemblies\2019\$(TargetName).nll.dll"
 if exist "D:\Programmes\Autodesk\Maya2019\bin\plug-ins\" copy "$(SolutionDir)assemblies\2019\*.dll" "D:\Programmes\Autodesk\Maya2019\bin\plug-ins\"
 if exist "C:\Program Files\Autodesk\Maya2019\bin\plug-ins\" copy "$(SolutionDir)assemblies\2019\*.dll" "C:\Program Files\Autodesk\Maya2019\bin\plug-ins\"
 

--- a/Maya/Maya2Babylon2020.csproj
+++ b/Maya/Maya2Babylon2020.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Maya2Babylon</RootNamespace>
-    <AssemblyName>Maya2Babylon</AssemblyName>
+    <AssemblyName>Maya2Babylon.nll</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -171,8 +171,6 @@ ECHO %25configurationName%25
 if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
 if not exist "$(SolutionDir)assemblies\2020" mkdir "$(SolutionDir)assemblies\2020"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2020\"
-del "$(SolutionDir)assemblies\2020\$(TargetName).dll"
-copy "$(TargetPath)" "$(SolutionDir)assemblies\2020\$(TargetName).nll.dll"
 if exist "D:\Programmes\Autodesk\Maya2020\bin\plug-ins\" copy "$(SolutionDir)assemblies\2020\*.dll" "D:\Programmes\Autodesk\Maya2020\bin\plug-ins\"
 if exist "C:\Program Files\Autodesk\Maya2020\bin\plug-ins\" copy "$(SolutionDir)assemblies\2020\*.dll" "C:\Program Files\Autodesk\Maya2020\bin\plug-ins\"
 

--- a/Maya/Maya2Babylon2022.csproj
+++ b/Maya/Maya2Babylon2022.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Maya2Babylon</RootNamespace>
-    <AssemblyName>Maya2Babylon</AssemblyName>
+    <AssemblyName>Maya2Babylon.nll</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -163,7 +163,8 @@
   <Import Project="..\SharedProjects\BabylonExport.Entities\BabylonExport.Entities.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>setlocal enabledelayedexpansion
+    <PostBuildEvent>
+setlocal enabledelayedexpansion
 
 SET configurationName=$(ConfigurationName)
 ECHO %25configurationName%25
@@ -171,12 +172,10 @@ ECHO %25configurationName%25
 if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
 if not exist "$(SolutionDir)assemblies\2022" mkdir "$(SolutionDir)assemblies\2022"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2022\"
-del "$(SolutionDir)assemblies\2022\$(TargetName).dll"
-copy "$(TargetPath)" "$(SolutionDir)assemblies\2022\$(TargetName).nll.dll"
 if exist "D:\Programmes\Autodesk\Maya2022\bin\plug-ins\" copy "$(SolutionDir)assemblies\2022\*.dll" "D:\Programmes\Autodesk\Maya2022\bin\plug-ins\"
 if exist "C:\Program Files\Autodesk\Maya2022\bin\plug-ins\" copy "$(SolutionDir)assemblies\2022\*.dll" "C:\Program Files\Autodesk\Maya2022\bin\plug-ins\"
 
-IF "%25configurationName%25"=="Debug" GOTO DebugOnMaya 
+IF "%25configurationName%25"=="Debug" GOTO DebugOnMaya
 GOTO Close
 
 :DebugOnMaya
@@ -185,7 +184,8 @@ GOTO Close
 
 :Close
 PAUSE
-EXIT</PostBuildEvent>
+EXIT
+</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>setlocal enabledelayedexpansion

--- a/Maya/Maya2Babylon2023.csproj
+++ b/Maya/Maya2Babylon2023.csproj
@@ -167,7 +167,7 @@
 
 SET configurationName=$(ConfigurationName)
 ECHO %25configurationName%25
-
+ 
 if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
 if not exist "$(SolutionDir)assemblies\2023" mkdir "$(SolutionDir)assemblies\2023"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2023\"

--- a/Maya/Maya2Babylon2023.csproj
+++ b/Maya/Maya2Babylon2023.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Maya2Babylon</RootNamespace>
-    <AssemblyName>Maya2Babylon</AssemblyName>
+    <AssemblyName>Maya2Babylon.nll</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -171,12 +171,10 @@ ECHO %25configurationName%25
 if not exist "$(SolutionDir)assemblies" mkdir "$(SolutionDir)assemblies"
 if not exist "$(SolutionDir)assemblies\2023" mkdir "$(SolutionDir)assemblies\2023"
 copy "$(TargetDir)*.dll" "$(SolutionDir)assemblies\2023\"
-del "$(SolutionDir)assemblies\2023\$(TargetName).dll"
-copy "$(TargetPath)" "$(SolutionDir)assemblies\2023\$(TargetName).nll.dll"
 if exist "D:\Programmes\Autodesk\Maya2023\bin\plug-ins\" copy "$(SolutionDir)assemblies\2023\*.dll" "D:\Programmes\Autodesk\Maya2023\bin\plug-ins\"
 if exist "C:\Program Files\Autodesk\Maya2023\bin\plug-ins\" copy "$(SolutionDir)assemblies\2023\*.dll" "C:\Program Files\Autodesk\Maya2023\bin\plug-ins\"
 
-IF "%25configurationName%25"=="Debug" GOTO DebugOnMaya 
+IF "%25configurationName%25"=="Debug" GOTO DebugOnMaya
 GOTO Close
 
 :DebugOnMaya


### PR DESCRIPTION
Remove mandatory rename operation for Maya plug-in, by updating the build scripts.