### PR TITLE
add secondary lowercase test when looking for material property by name

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -57,6 +57,14 @@ namespace Max2Babylon
             {
                 return texmap;
             }
+
+            // sometime the name of the material changed - plugin side effect with script material
+            // so give a second chance with lowercase to be more resilient
+            if (_mapCaches.TryGetValue(name.ToLower(), out texmap))
+            {
+                return texmap;
+            }
+
             // max 2022 maj introduce a change into the naming of the map.
             // the SDK do not return the name of the map anymore but a display name with camel style and space
             // Here a fix which maintain the old style and transform the name for a second try if failed.
@@ -75,7 +83,10 @@ namespace Max2Babylon
             {
                 for (int i = 0; i < materialNode.MaxMaterial.NumSubTexmaps; i++)
                 {
-                    if (materialNode.MaxMaterial.GetSubTexmapSlotName(i) == name)
+                    var slotName = materialNode.MaxMaterial.GetSubTexmapSlotName(i);
+                    // sometime the name of the material changed - plugin side effect with script material
+                    // so give a second chance with lowercase to be more resilient
+                    if (slotName == name || slotName == name.ToLower())
                     {
                         return materialNode.MaxMaterial.GetSubTexmap(i);
                     }
@@ -89,6 +100,7 @@ namespace Max2Babylon
         }
 
     }
+
 
     /// <summary>
     /// Babylon custom attribute decorator


### PR DESCRIPTION
sometime the names of the material properties may changed - often is a third party plugin side effect with script material. 
so give a second chance with lowercase search to be more resilient.
for sample normal map will be now search using `"nomalMap"`, then `"normalmap"` and finally `" _NormalMap"`
remember that the last one is a fix for some 2022 version
fix #1072 

 