### PR TITLE
Fixed URLs for documentation pages

### DIFF
--- a/3ds Max/readme.md
+++ b/3ds Max/readme.md
@@ -1,7 +1,7 @@
 3DS Max to Babylon.js exporter
 ==============================
 
-Documentation: https://doc.babylonjs.com/resources/3dsmax
+Documentation: https://doc.babylonjs.com/features/featuresDeepDive/Exporters/3DSMax
 
 # How to contribute:
 ## Requirements:

--- a/Cheetah3d/README.md
+++ b/Cheetah3d/README.md
@@ -1,4 +1,4 @@
 Cheetah to Babylon.js exporter
 ==============================
 
-Documentation: http://doc.babylonjs.com/exporters/cheetah3d
+Documentation: http://doc.babylonjs.com/features/featuresDeepDive/Exporters/Cheetah3D

--- a/Maya/readme.md
+++ b/Maya/readme.md
@@ -1,7 +1,7 @@
 Maya to Babylon.js exporter
 ==============================
 
-Documentation: http://doc.babylonjs.com/resources/maya
+Documentation: https://doc.babylonjs.com/features/featuresDeepDive/Exporters/Maya
 
 # How to contribute:
 ## Requirements:

--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,10 @@ For alternative export options, please see this doc: https://doc.babylonjs.com/p
 
 **Get the latest installer for our exporters here: https://github.com/BabylonJS/Exporters/releases**
 
-Documentation on the 3ds Max exporter is available here: https://doc.babylonjs.com/resources/3dsmax<br />
-Documentation for exporting from 3ds Max to glTF is available here: https://doc.babylonjs.com/resources/3dsmax_to_gltf
+Documentation on the 3ds Max exporter is available here: https://doc.babylonjs.com/features/featuresDeepDive/Exporters/3DSMax<br />
+Documentation for exporting from 3ds Max to glTF is available here: https://doc.babylonjs.com/features/featuresDeepDive/Exporters/3DSMax_to_glTF
 
-Documentation on the Maya exporter is available here: https://doc.babylonjs.com/resources/maya<br />
-Documentation for exporting from Maya to glTF is available here: https://doc.babylonjs.com/resources/maya_to_gltf
+Documentation on the Maya exporter is available here: https://doc.babylonjs.com/features/featuresDeepDive/Exporters/Maya<br />
+Documentation for exporting from Maya to glTF is available here: https://doc.babylonjs.com/features/featuresDeepDive/Exporters/Maya_to_glTF
 
 **Any questions?** Here is our official [forum](https://forum.babylonjs.com/).


### PR DESCRIPTION
Fixed URLs that point to babylonjs documentation pages. After the website got restructured those URLs became invalid. 