### PR TITLE
Add check for invalid tangent data in Maya 

### DIFF
--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -919,15 +919,24 @@ namespace Maya2Babylon
                 {
                     MVector tangent = new MVector();
                     mFnMesh.getFaceVertexTangent(polygonId, vertexIndexGlobal, tangent);
+                    tangent.normalize();
+                    
+                    if (tangent.length < 0.1)
+                    {
+                        isTangentExportSuccess = false;
+                        RaiseWarning($"Mesh has invalid tangent data. Exporter will not export tangets for the mesh {mFnMesh?.name ?? "Unknown"}");
+                    }
+                    else
+                    {
+                        // Switch coordinate system at object level
+                        tangent.z *= -1;
 
-                    // Switch coordinate system at object level
-                    tangent.z *= -1;
+                        int tangentId = mFnMesh.getTangentId(polygonId, vertexIndexGlobal);
+                        bool isRightHandedTangent = mFnMesh.isRightHandedTangent(tangentId);
 
-                    int tangentId = mFnMesh.getTangentId(polygonId, vertexIndexGlobal);
-                    bool isRightHandedTangent = mFnMesh.isRightHandedTangent(tangentId);
-
-                    // Invert W to switch to left handed system
-                    vertex.Tangent = new float[] { (float)tangent.x, (float)tangent.y, (float)tangent.z, isRightHandedTangent ? -1 : 1 };
+                        // Invert W to switch to left handed system
+                        vertex.Tangent = new float[] { (float)tangent.x, (float)tangent.y, (float)tangent.z, isRightHandedTangent ? -1 : 1 };
+                    }
                 }
                 catch
                 {
@@ -1341,15 +1350,24 @@ namespace Maya2Babylon
                                     {
                                         MVector tangent = new MVector();
                                         targetMesh.getFaceVertexTangent(vertexData.polygonId, vertexData.vertexIndexGlobal, tangent);
+                                        tangent.normalize();
 
-                                        // Switch coordinate system at object level
-                                        tangent.z *= -1;
+                                        if (tangent.length < 0.1)
+                                        {
+                                            isTangentExportSuccess = false;
+                                            RaiseWarning($"Mesh has invalid tangent data. Exporter will not export tangets for the mesh {mesh?.name ?? "Unknown"}");
+                                        }
+                                        else
+                                        {
+                                            // Switch coordinate system at object level
+                                            tangent.z *= -1;
 
-                                        int tangentId = targetMesh.getTangentId(vertexData.polygonId, vertexData.vertexIndexGlobal);
-                                        bool isRightHandedTangent = targetMesh.isRightHandedTangent(tangentId);
+                                            int tangentId = targetMesh.getTangentId(vertexData.polygonId, vertexData.vertexIndexGlobal);
+                                            bool isRightHandedTangent = targetMesh.isRightHandedTangent(tangentId);
 
-                                        // Invert W to switch to left handed system
-                                        vertex.Tangent = new float[] { (float)tangent.x, (float)tangent.y, (float)tangent.z, isRightHandedTangent ? -1 : 1 };
+                                            // Invert W to switch to left handed system
+                                            vertex.Tangent = new float[] { (float)tangent.x, (float)tangent.y, (float)tangent.z, isRightHandedTangent ? -1 : 1 };
+                                        }
                                     }
                                     catch
                                     {

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -15,7 +15,7 @@ namespace Maya2Babylon
         private MStringArray allMayaInfluenceNames;     // the joint names that influence the mesh (joint with 0 weight included)
         private MDoubleArray allMayaInfluenceWeights;   // the joint weights for the vertex (0 weight included)
         private Dictionary<string, int> indexByNodeName = new Dictionary<string, int>();    // contains the node (joint and parents of the current skin) fullPathName and its index
-        
+
         /// <summary>
         /// 
         /// </summary>
@@ -919,15 +919,16 @@ namespace Maya2Babylon
                 {
                     MVector tangent = new MVector();
                     mFnMesh.getFaceVertexTangent(polygonId, vertexIndexGlobal, tangent);
-                    tangent.normalize();
                     
-                    if (tangent.length < 0.1)
+                    if (tangent.isEquivalent(MVector.zero))
                     {
                         isTangentExportSuccess = false;
                         RaiseWarning($"Mesh has invalid tangent data. Exporter will not export tangets for the mesh {mFnMesh?.name ?? "Unknown"}");
                     }
                     else
                     {
+                        tangent.normalize();
+
                         // Switch coordinate system at object level
                         tangent.z *= -1;
 
@@ -1350,15 +1351,16 @@ namespace Maya2Babylon
                                     {
                                         MVector tangent = new MVector();
                                         targetMesh.getFaceVertexTangent(vertexData.polygonId, vertexData.vertexIndexGlobal, tangent);
-                                        tangent.normalize();
 
-                                        if (tangent.length < 0.1)
+                                        if (tangent.isEquivalent(MVector.zero))
                                         {
                                             isTangentExportSuccess = false;
                                             RaiseWarning($"Mesh has invalid tangent data. Exporter will not export tangets for the mesh {mesh?.name ?? "Unknown"}");
                                         }
                                         else
                                         {
+                                            tangent.normalize();
+                                            
                                             // Switch coordinate system at object level
                                             tangent.z *= -1;
 


### PR DESCRIPTION
It is possible that Maya returns a vector with values 0,0,0 when exporting tangent data for mesh.  If mesh has invalid model data we should not export it to avoid creating an invalid GLB. 

Fix #1131 