### PR TITLE
Added support for 16bit bone indexes  

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -1358,7 +1358,7 @@ namespace Max2Babylon
                 }
 
                 vertex.Weights = Loader.Global.Point4.Create(weight);
-                vertex.BonesIndices = (bone[3] << 24) | (bone[2] << 16) | (bone[1] << 8) | bone[0];
+                vertex.BonesIndices = (bone[3] << 48) | (bone[2] << 32) | (bone[1] << 16) | bone[0];
 
                 if (currentVtxBone >= 4 && currentSkinBone < nbBones)
                 {
@@ -1387,7 +1387,7 @@ namespace Max2Babylon
                     if (currentVtxBone > 4)
                     {
                         vertex.WeightsExtra = Loader.Global.Point4.Create(weight);
-                        vertex.BonesIndicesExtra = (bone[3] << 24) | (bone[2] << 16) | (bone[1] << 8) | bone[0];
+                        vertex.BonesIndicesExtra = (bone[3] << 48) | (bone[2] << 32) | (bone[1] << 16) | bone[0];
 
                         if (currentSkinBone < nbBones)
                         {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -28,7 +28,7 @@ namespace Max2Babylon
                     bool initialized = gameMesh.InitializeData; // needed, the property is in fact a method initializing the exporter that has wrongly been auto 
                                                                 // translated into a property because it has no parameters
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     RaiseWarning($"Mesh {meshNode.Name} failed to initialize.", 2);
                 }
@@ -148,7 +148,7 @@ namespace Max2Babylon
                 bool initialized = gameMesh.InitializeData; // needed, the property is in fact a method initializing the exporter that has wrongly been auto 
                                                             // translated into a property because it has no parameters
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 RaiseWarning($"Mesh {meshNode.Name} failed to initialize. Mesh is exported as dummy.", 2);
                 return ExportDummy(scene, meshNode, babylonScene);
@@ -494,14 +494,14 @@ namespace Max2Babylon
                 if (skin != null) 
                 {
                     babylonMesh.matricesWeights = vertices.SelectMany(v => v.Weights.ToArray()).ToArray();
-                    babylonMesh.matricesIndices = vertices.SelectMany(v => v.BonesIndices.ToArray()).ToArray();
+                    babylonMesh.matricesIndices = vertices.SelectMany(v => v.BonesIndices.Select(a => (uint)a)).ToArray();
 
                     babylonMesh.numBoneInfluencers = maxNbBones;
 
                     if (maxNbBones > 4)
                     {
                         babylonMesh.matricesWeightsExtra = vertices.SelectMany(v => v.WeightsExtra != null ? v.WeightsExtra.ToArray() : new[] { 0.0f, 0.0f, 0.0f, 0.0f }).ToArray();
-                        babylonMesh.matricesIndicesExtra = vertices.SelectMany(v => v.BonesIndicesExtra.ToArray()).ToArray();
+                        babylonMesh.matricesIndicesExtra = vertices.SelectMany(v => v.BonesIndicesExtra != null ? v.BonesIndicesExtra.Select(a => (uint)a) : new uint[] { 0, 0, 0, 0}).ToArray();
                     }
                 }
 
@@ -776,7 +776,7 @@ namespace Max2Babylon
                     }
                     RaiseMessage(d.Count + " User defined properties", 2);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     RaiseWarning("Failed to parse user defined properties: " + userProp, 2);
                 }
@@ -1330,7 +1330,7 @@ namespace Max2Babylon
             if (skin != null)
             {
                 float[] weight = new float[4] { 0, 0, 0, 0 };
-                int[] bone = new int[4] { 0, 0, 0, 0 };
+                ushort[] bone = new ushort[4] { 0, 0, 0, 0 };
                 var nbBones = skin.GetNumberOfBones(vertexIndex);
                 // Babylon, nor GLTF do not support single bone skeleton, we may add a root node  with no transform.
                 // this is echoing the process into BabylonExporter.Skeleton ExportBones(Skin)
@@ -1346,7 +1346,7 @@ namespace Max2Babylon
                     if (boneWeight <= 0)
                         continue;
 
-                    bone[currentVtxBone] = boneIds.IndexOf(skin.GetIGameBone(vertexIndex, currentSkinBone).NodeID) + offset; // add optional offset
+                    bone[currentVtxBone] = (ushort)(boneIds.IndexOf(skin.GetIGameBone(vertexIndex, currentSkinBone).NodeID) + offset); // add optional offset
                     weight[currentVtxBone] = skin.GetWeight(vertexIndex, currentSkinBone);
                     ++currentVtxBone;
                 }
@@ -1364,7 +1364,7 @@ namespace Max2Babylon
                 if (currentVtxBone >= 4 && currentSkinBone < nbBones)
                 {
                     weight = new float[4] { 0, 0, 0, 0 };
-                    bone = new int[4] { 0, 0, 0, 0 };
+                    bone = new ushort[4] { 0, 0, 0, 0 };
 
                     // process remaining skin bones until we have a total of 8 bones for this vertex or we run out of skin bones
                     for (; currentSkinBone < nbBones && currentVtxBone < 8; ++currentSkinBone)
@@ -1379,7 +1379,7 @@ namespace Max2Babylon
                             break;
                         }
 
-                        bone[currentVtxBone - 4] = boneIds.IndexOf(skin.GetIGameBone(vertexIndex, currentSkinBone).NodeID) + offset; // add optional offset
+                        bone[currentVtxBone - 4] = (ushort)(boneIds.IndexOf(skin.GetIGameBone(vertexIndex, currentSkinBone).NodeID) + offset); // add optional offset
                         weight[currentVtxBone - 4] = skin.GetWeight(vertexIndex, currentSkinBone);
                         ++currentVtxBone;
                     }

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Mesh.cs
@@ -494,13 +494,14 @@ namespace Max2Babylon
                 if (skin != null) 
                 {
                     babylonMesh.matricesWeights = vertices.SelectMany(v => v.Weights.ToArray()).ToArray();
-                    babylonMesh.matricesIndices = vertices.Select(v => v.BonesIndices).ToArray();
+                    babylonMesh.matricesIndices = vertices.SelectMany(v => v.BonesIndices.ToArray()).ToArray();
 
                     babylonMesh.numBoneInfluencers = maxNbBones;
+
                     if (maxNbBones > 4)
                     {
                         babylonMesh.matricesWeightsExtra = vertices.SelectMany(v => v.WeightsExtra != null ? v.WeightsExtra.ToArray() : new[] { 0.0f, 0.0f, 0.0f, 0.0f }).ToArray();
-                        babylonMesh.matricesIndicesExtra = vertices.Select(v => v.BonesIndicesExtra).ToArray();
+                        babylonMesh.matricesIndicesExtra = vertices.SelectMany(v => v.BonesIndicesExtra.ToArray()).ToArray();
                     }
                 }
 
@@ -1358,7 +1359,7 @@ namespace Max2Babylon
                 }
 
                 vertex.Weights = Loader.Global.Point4.Create(weight);
-                vertex.BonesIndices = (bone[3] << 48) | (bone[2] << 32) | (bone[1] << 16) | bone[0];
+                vertex.BonesIndices = bone;
 
                 if (currentVtxBone >= 4 && currentSkinBone < nbBones)
                 {
@@ -1387,7 +1388,7 @@ namespace Max2Babylon
                     if (currentVtxBone > 4)
                     {
                         vertex.WeightsExtra = Loader.Global.Point4.Create(weight);
-                        vertex.BonesIndicesExtra = (bone[3] << 48) | (bone[2] << 32) | (bone[1] << 16) | bone[0];
+                        vertex.BonesIndicesExtra = bone;
 
                         if (currentSkinBone < nbBones)
                         {

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -767,6 +767,11 @@ namespace Max2Babylon
             babylonScene.Prepare(false, false);
             if (isBabylonExported)
             {
+                if (!babylonScene.PackIndexArrays())
+                {
+                    RaiseWarning("Model has too many skeleton joints. The .babylon file will store joint indicies using expandanded form, this will only load properly using Babylon.js >= 8.5.0.");
+                }
+                
                 RaiseMessage("Saving to output file");
 
                 var outputFile = Path.Combine(outputBabylonDirectory, outputFileName);

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.cs
@@ -767,7 +767,7 @@ namespace Max2Babylon
             babylonScene.Prepare(false, false);
             if (isBabylonExported)
             {
-                if (!babylonScene.PackIndexArrays())
+                if (!babylonScene.TryPackIndexArrays())
                 {
                     RaiseWarning("Model has too many skeleton joints. The .babylon file will store joint indicies using expandanded form, this will only load properly using Babylon.js >= 8.5.0.");
                 }

--- a/3ds Max/Max2Babylon/Exporter/GlobalVertex.cs
+++ b/3ds Max/Max2Babylon/Exporter/GlobalVertex.cs
@@ -19,9 +19,9 @@ namespace Max2Babylon
         public IPoint2 UV6 { get; set; }
         public IPoint2 UV7 { get; set; }
         public IPoint2 UV8 { get; set; }
-        public int BonesIndices { get; set; }
+        public long BonesIndices { get; set; }
         public IPoint4 Weights { get; set; }
-        public int BonesIndicesExtra { get; set; }
+        public long BonesIndicesExtra { get; set; }
         public IPoint4 WeightsExtra { get; set; }
         public float[] Color { get; set; }
 

--- a/3ds Max/Max2Babylon/Exporter/GlobalVertex.cs
+++ b/3ds Max/Max2Babylon/Exporter/GlobalVertex.cs
@@ -19,9 +19,9 @@ namespace Max2Babylon
         public IPoint2 UV6 { get; set; }
         public IPoint2 UV7 { get; set; }
         public IPoint2 UV8 { get; set; }
-        public long BonesIndices { get; set; }
+        public int[] BonesIndices { get; set; }
         public IPoint4 Weights { get; set; }
-        public long BonesIndicesExtra { get; set; }
+        public int[] BonesIndicesExtra { get; set; }
         public IPoint4 WeightsExtra { get; set; }
         public float[] Color { get; set; }
 

--- a/3ds Max/Max2Babylon/Exporter/GlobalVertex.cs
+++ b/3ds Max/Max2Babylon/Exporter/GlobalVertex.cs
@@ -19,9 +19,9 @@ namespace Max2Babylon
         public IPoint2 UV6 { get; set; }
         public IPoint2 UV7 { get; set; }
         public IPoint2 UV8 { get; set; }
-        public int[] BonesIndices { get; set; }
+        public ushort[] BonesIndices { get; set; }
         public IPoint4 Weights { get; set; }
-        public int[] BonesIndicesExtra { get; set; }
+        public ushort[] BonesIndicesExtra { get; set; }
         public IPoint4 WeightsExtra { get; set; }
         public float[] Color { get; set; }
 

--- a/3ds Max/Max2Babylon/Forms/ExporterForm.cs
+++ b/3ds Max/Max2Babylon/Forms/ExporterForm.cs
@@ -449,7 +449,7 @@ namespace Max2Babylon
                 {
                     scaleFactorParsed = float.Parse(txtScaleFactor.Text);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     throw new InvalidDataException(String.Format("Invalid Scale Factor value: {0}", txtScaleFactor.Text));
                 }
@@ -457,7 +457,7 @@ namespace Max2Babylon
                 {
                     textureQualityParsed = long.Parse(txtQuality.Text);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     throw new InvalidDataException(String.Format("Invalid Texture Quality value: {0}", txtScaleFactor.Text));
                 }

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -16,15 +16,6 @@ namespace Maya2Babylon
         private MDoubleArray allMayaInfluenceWeights;   // the joint weights for the vertex (0 weight included)
         private Dictionary<string, int> indexByNodeName = new Dictionary<string, int>();    // contains the node (joint and parents of the current skin) fullPathName and its index
 
-        private int CheckBoneBoundaries(int boneValue)
-        {
-            if (boneValue >= 255)
-            {
-                //throw new ArgumentOutOfRangeException("Bone out of byte range");
-            }
-
-            return boneValue;
-        }
 
         /// <summary>
         /// 
@@ -1047,22 +1038,22 @@ namespace Maya2Babylon
 
                 if (nbBones > 0)
                 {
-                    bone0 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(0).Key);
+                    bone0 = weightByInfluenceIndex.ElementAt(0).Key;
                     weight0 = (float)weightByInfluenceIndex.ElementAt(0).Value;
 
                     if (nbBones > 1)
                     {
-                        bone1 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(1).Key);
+                        bone1 = weightByInfluenceIndex.ElementAt(1).Key;
                         weight1 = (float)weightByInfluenceIndex.ElementAt(1).Value;
 
                         if (nbBones > 2)
                         {
-                            bone2 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(2).Key);
+                            bone2 = weightByInfluenceIndex.ElementAt(2).Key;
                             weight2 = (float)weightByInfluenceIndex.ElementAt(2).Value;
 
                             if (nbBones > 3)
                             {
-                                bone3 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(3).Key);
+                                bone3 = weightByInfluenceIndex.ElementAt(3).Key;
                                 weight3 = (float)weightByInfluenceIndex.ElementAt(3).Value;
                             }
                         }
@@ -1075,7 +1066,7 @@ namespace Maya2Babylon
 
                 if (nbBones > 4)
                 {
-                    bone0 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(4).Key);
+                    bone0 = weightByInfluenceIndex.ElementAt(4).Key;
                     weight0 = (float)weightByInfluenceIndex.ElementAt(4).Value;
                     weight1 = 0;
                     weight2 = 0;
@@ -1083,17 +1074,17 @@ namespace Maya2Babylon
 
                     if (nbBones > 5)
                     {
-                        bone1 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(5).Key);
+                        bone1 = weightByInfluenceIndex.ElementAt(5).Key;
                         weight1 = (float)weightByInfluenceIndex.ElementAt(4).Value;
 
                         if (nbBones > 6)
                         {
-                            bone2 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(6).Key);
+                            bone2 = weightByInfluenceIndex.ElementAt(6).Key;
                             weight2 = (float)weightByInfluenceIndex.ElementAt(4).Value;
 
                             if (nbBones > 7)
                             {
-                                bone3 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(7).Key);
+                                bone3 = weightByInfluenceIndex.ElementAt(7).Key;
                                 weight3 = (float)weightByInfluenceIndex.ElementAt(7).Value;
                             }
                         }

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -1019,15 +1019,15 @@ namespace Maya2Babylon
                 // decreasing sort
                 OrderByDescending(ref weightByInfluenceIndex);
 
-                long bonesCount = indexByNodeName.Count; // number total of bones/influences for the mesh
+                int bonesCount = indexByNodeName.Count; // number total of bones/influences for the mesh
                 float weight0 = 0;
                 float weight1 = 0;
                 float weight2 = 0;
                 float weight3 = 0;
-                long bone0 = 0;
-                long bone1 = 0;
-                long bone2 = 0;
-                long bone3 = 0;
+                int bone0 = 0;
+                int bone1 = 0;
+                int bone2 = 0;
+                int bone3 = 0;
                 int nbBones = weightByInfluenceIndex.Count; // number of bones/influences for this vertex
 
                 if (nbBones == 0)
@@ -1062,7 +1062,7 @@ namespace Maya2Babylon
 
                 float[] weights = { weight0, weight1, weight2, weight3 };
                 vertex.Weights = weights;
-                int[] boneIndexes = { (int)bone0, (int)bone1, (int)bone2, (int)bone3 };
+                int[] boneIndexes = { bone0, bone1, bone2, bone3 };
                 vertex.BonesIndices = boneIndexes;
 
                 if (nbBones > 4)
@@ -1093,7 +1093,7 @@ namespace Maya2Babylon
 
                     float[] weightsExtra = { weight0, weight1, weight2, weight3 };
                     vertex.WeightsExtra = weightsExtra;
-                    int[] boneIndexesExtra = { (int)bone0, (int)bone1, (int)bone2, (int)bone3 };
+                    int[] boneIndexesExtra = { bone0, bone1, bone2, bone3 };
                     vertex.BonesIndicesExtra = boneIndexesExtra;
                 }
             }

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -561,13 +561,13 @@ namespace Maya2Babylon
             if (mFnSkinCluster != null)
             {
                 babylonMesh.matricesWeights = vertices.SelectMany(v => v.Weights.ToArray()).ToArray();
-                babylonMesh.matricesIndices = vertices.SelectMany(v => v.BonesIndices.ToArray()).ToArray();
+                babylonMesh.matricesIndices = vertices.SelectMany(v => v.BonesIndices.Select(a => (uint)a)).ToArray();
 
                 babylonMesh.numBoneInfluencers = maxNbBones;
                 if (maxNbBones > 4)
                 {
                     babylonMesh.matricesWeightsExtra = vertices.SelectMany(v => v.WeightsExtra != null ? v.WeightsExtra.ToArray() : new[] { 0.0f, 0.0f, 0.0f, 0.0f }).ToArray();
-                    babylonMesh.matricesIndicesExtra = vertices.SelectMany(v => v.BonesIndicesExtra != null ? v.BonesIndicesExtra.ToArray() : new int[] { 0, 0, 0, 0 }).ToArray();
+                    babylonMesh.matricesIndicesExtra = vertices.SelectMany(v => v.BonesIndicesExtra != null ? v.BonesIndicesExtra.Select(a => (uint)a) : new uint[] { 0, 0, 0, 0 }).ToArray();
                 }
             }
 
@@ -1024,36 +1024,36 @@ namespace Maya2Babylon
                 float weight1 = 0;
                 float weight2 = 0;
                 float weight3 = 0;
-                int bone0 = 0;
-                int bone1 = 0;
-                int bone2 = 0;
-                int bone3 = 0;
+                ushort bone0 = 0;
+                ushort bone1 = 0;
+                ushort bone2 = 0;
+                ushort bone3 = 0;
                 int nbBones = weightByInfluenceIndex.Count; // number of bones/influences for this vertex
 
                 if (nbBones == 0)
                 {
                     weight0 = 1.0f;
-                    bone0 = bonesCount;
+                    bone0 = (ushort)bonesCount;
                 }
 
                 if (nbBones > 0)
                 {
-                    bone0 = weightByInfluenceIndex.ElementAt(0).Key;
+                    bone0 = (ushort)weightByInfluenceIndex.ElementAt(0).Key;
                     weight0 = (float)weightByInfluenceIndex.ElementAt(0).Value;
 
                     if (nbBones > 1)
                     {
-                        bone1 = weightByInfluenceIndex.ElementAt(1).Key;
+                        bone1 = (ushort)weightByInfluenceIndex.ElementAt(1).Key;
                         weight1 = (float)weightByInfluenceIndex.ElementAt(1).Value;
 
                         if (nbBones > 2)
                         {
-                            bone2 = weightByInfluenceIndex.ElementAt(2).Key;
+                            bone2 = (ushort)weightByInfluenceIndex.ElementAt(2).Key;
                             weight2 = (float)weightByInfluenceIndex.ElementAt(2).Value;
 
                             if (nbBones > 3)
                             {
-                                bone3 = weightByInfluenceIndex.ElementAt(3).Key;
+                                bone3 = (ushort)weightByInfluenceIndex.ElementAt(3).Key;
                                 weight3 = (float)weightByInfluenceIndex.ElementAt(3).Value;
                             }
                         }
@@ -1062,12 +1062,12 @@ namespace Maya2Babylon
 
                 float[] weights = { weight0, weight1, weight2, weight3 };
                 vertex.Weights = weights;
-                int[] boneIndexes = { bone0, bone1, bone2, bone3 };
+                ushort[] boneIndexes = { bone0, bone1, bone2, bone3 };
                 vertex.BonesIndices = boneIndexes;
 
                 if (nbBones > 4)
                 {
-                    bone0 = weightByInfluenceIndex.ElementAt(4).Key;
+                    bone0 = (ushort)weightByInfluenceIndex.ElementAt(4).Key;
                     weight0 = (float)weightByInfluenceIndex.ElementAt(4).Value;
                     weight1 = 0;
                     weight2 = 0;
@@ -1075,17 +1075,17 @@ namespace Maya2Babylon
 
                     if (nbBones > 5)
                     {
-                        bone1 = weightByInfluenceIndex.ElementAt(5).Key;
+                        bone1 = (ushort)weightByInfluenceIndex.ElementAt(5).Key;
                         weight1 = (float)weightByInfluenceIndex.ElementAt(4).Value;
 
                         if (nbBones > 6)
                         {
-                            bone2 = weightByInfluenceIndex.ElementAt(6).Key;
+                            bone2 = (ushort)weightByInfluenceIndex.ElementAt(6).Key;
                             weight2 = (float)weightByInfluenceIndex.ElementAt(4).Value;
 
                             if (nbBones > 7)
                             {
-                                bone3 = weightByInfluenceIndex.ElementAt(7).Key;
+                                bone3 = (ushort)weightByInfluenceIndex.ElementAt(7).Key;
                                 weight3 = (float)weightByInfluenceIndex.ElementAt(7).Value;
                             }
                         }
@@ -1093,7 +1093,7 @@ namespace Maya2Babylon
 
                     float[] weightsExtra = { weight0, weight1, weight2, weight3 };
                     vertex.WeightsExtra = weightsExtra;
-                    int[] boneIndexesExtra = { bone0, bone1, bone2, bone3 };
+                    ushort[] boneIndexesExtra = { bone0, bone1, bone2, bone3 };
                     vertex.BonesIndicesExtra = boneIndexesExtra;
                 }
             }

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -16,6 +16,16 @@ namespace Maya2Babylon
         private MDoubleArray allMayaInfluenceWeights;   // the joint weights for the vertex (0 weight included)
         private Dictionary<string, int> indexByNodeName = new Dictionary<string, int>();    // contains the node (joint and parents of the current skin) fullPathName and its index
 
+        private int CheckBoneBoundaries(int boneValue)
+        {
+            if (boneValue >= 255)
+            {
+                //throw new ArgumentOutOfRangeException("Bone out of byte range");
+            }
+
+            return boneValue;
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -1018,15 +1028,15 @@ namespace Maya2Babylon
                 // decreasing sort
                 OrderByDescending(ref weightByInfluenceIndex);
 
-                int bonesCount = indexByNodeName.Count; // number total of bones/influences for the mesh
+                long bonesCount = indexByNodeName.Count; // number total of bones/influences for the mesh
                 float weight0 = 0;
                 float weight1 = 0;
                 float weight2 = 0;
                 float weight3 = 0;
-                int bone0 = 0;
-                int bone1 = 0;
-                int bone2 = 0;
-                int bone3 = 0;
+                long bone0 = 0;
+                long bone1 = 0;
+                long bone2 = 0;
+                long bone3 = 0;
                 int nbBones = weightByInfluenceIndex.Count; // number of bones/influences for this vertex
 
                 if (nbBones == 0)
@@ -1037,22 +1047,22 @@ namespace Maya2Babylon
 
                 if (nbBones > 0)
                 {
-                    bone0 = weightByInfluenceIndex.ElementAt(0).Key;
+                    bone0 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(0).Key);
                     weight0 = (float)weightByInfluenceIndex.ElementAt(0).Value;
 
                     if (nbBones > 1)
                     {
-                        bone1 = weightByInfluenceIndex.ElementAt(1).Key;
+                        bone1 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(1).Key);
                         weight1 = (float)weightByInfluenceIndex.ElementAt(1).Value;
 
                         if (nbBones > 2)
                         {
-                            bone2 = weightByInfluenceIndex.ElementAt(2).Key;
+                            bone2 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(2).Key);
                             weight2 = (float)weightByInfluenceIndex.ElementAt(2).Value;
 
                             if (nbBones > 3)
                             {
-                                bone3 = weightByInfluenceIndex.ElementAt(3).Key;
+                                bone3 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(3).Key);
                                 weight3 = (float)weightByInfluenceIndex.ElementAt(3).Value;
                             }
                         }
@@ -1061,11 +1071,11 @@ namespace Maya2Babylon
 
                 float[] weights = { weight0, weight1, weight2, weight3 };
                 vertex.Weights = weights;
-                vertex.BonesIndices = (bone3 << 24) | (bone2 << 16) | (bone1 << 8) | bone0;
+                vertex.BonesIndices = (bone3 << 48) | (bone2 << 32) | (bone1 << 16) | bone0;
 
                 if (nbBones > 4)
                 {
-                    bone0 = weightByInfluenceIndex.ElementAt(4).Key;
+                    bone0 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(4).Key);
                     weight0 = (float)weightByInfluenceIndex.ElementAt(4).Value;
                     weight1 = 0;
                     weight2 = 0;
@@ -1073,17 +1083,17 @@ namespace Maya2Babylon
 
                     if (nbBones > 5)
                     {
-                        bone1 = weightByInfluenceIndex.ElementAt(5).Key;
+                        bone1 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(5).Key);
                         weight1 = (float)weightByInfluenceIndex.ElementAt(4).Value;
 
                         if (nbBones > 6)
                         {
-                            bone2 = weightByInfluenceIndex.ElementAt(6).Key;
+                            bone2 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(6).Key);
                             weight2 = (float)weightByInfluenceIndex.ElementAt(4).Value;
 
                             if (nbBones > 7)
                             {
-                                bone3 = weightByInfluenceIndex.ElementAt(7).Key;
+                                bone3 = CheckBoneBoundaries(weightByInfluenceIndex.ElementAt(7).Key);
                                 weight3 = (float)weightByInfluenceIndex.ElementAt(7).Value;
                             }
                         }
@@ -1091,7 +1101,7 @@ namespace Maya2Babylon
 
                     float[] weightsExtra = { weight0, weight1, weight2, weight3 };
                     vertex.WeightsExtra = weightsExtra;
-                    vertex.BonesIndicesExtra = (bone3 << 24) | (bone2 << 16) | (bone1 << 8) | bone0;
+                    vertex.BonesIndicesExtra = (bone3 << 48) | (bone2 << 32) | (bone1 << 16) | bone0;
                 }
             }
             return vertex;

--- a/Maya/Exporter/BabylonExporter.Mesh.cs
+++ b/Maya/Exporter/BabylonExporter.Mesh.cs
@@ -561,13 +561,13 @@ namespace Maya2Babylon
             if (mFnSkinCluster != null)
             {
                 babylonMesh.matricesWeights = vertices.SelectMany(v => v.Weights.ToArray()).ToArray();
-                babylonMesh.matricesIndices = vertices.Select(v => v.BonesIndices).ToArray();
+                babylonMesh.matricesIndices = vertices.SelectMany(v => v.BonesIndices.ToArray()).ToArray();
 
                 babylonMesh.numBoneInfluencers = maxNbBones;
                 if (maxNbBones > 4)
                 {
                     babylonMesh.matricesWeightsExtra = vertices.SelectMany(v => v.WeightsExtra != null ? v.WeightsExtra.ToArray() : new[] { 0.0f, 0.0f, 0.0f, 0.0f }).ToArray();
-                    babylonMesh.matricesIndicesExtra = vertices.Select(v => v.BonesIndicesExtra).ToArray();
+                    babylonMesh.matricesIndicesExtra = vertices.SelectMany(v => v.BonesIndicesExtra != null ? v.BonesIndicesExtra.ToArray() : new int[] { 0, 0, 0, 0 }).ToArray();
                 }
             }
 
@@ -1062,7 +1062,8 @@ namespace Maya2Babylon
 
                 float[] weights = { weight0, weight1, weight2, weight3 };
                 vertex.Weights = weights;
-                vertex.BonesIndices = (bone3 << 48) | (bone2 << 32) | (bone1 << 16) | bone0;
+                int[] boneIndexes = { (int)bone0, (int)bone1, (int)bone2, (int)bone3 };
+                vertex.BonesIndices = boneIndexes;
 
                 if (nbBones > 4)
                 {
@@ -1092,7 +1093,8 @@ namespace Maya2Babylon
 
                     float[] weightsExtra = { weight0, weight1, weight2, weight3 };
                     vertex.WeightsExtra = weightsExtra;
-                    vertex.BonesIndicesExtra = (bone3 << 48) | (bone2 << 32) | (bone1 << 16) | bone0;
+                    int[] boneIndexesExtra = { (int)bone0, (int)bone1, (int)bone2, (int)bone3 };
+                    vertex.BonesIndicesExtra = boneIndexesExtra;
                 }
             }
             return vertex;

--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -513,7 +513,7 @@ namespace Maya2Babylon
 
             if (isBabylonExported)
             {
-                if (!babylonScene.PackIndexArrays())
+                if (!babylonScene.TryPackIndexArrays())
                 {
                     RaiseWarning("Model has too many skeleton joints. The .babylon file will store joint indicies using expandanded form, this will only load properly using Babylon.js >= 8.5.0.");
                 }

--- a/Maya/Exporter/BabylonExporter.cs
+++ b/Maya/Exporter/BabylonExporter.cs
@@ -513,6 +513,11 @@ namespace Maya2Babylon
 
             if (isBabylonExported)
             {
+                if (!babylonScene.PackIndexArrays())
+                {
+                    RaiseWarning("Model has too many skeleton joints. The .babylon file will store joint indicies using expandanded form, this will only load properly using Babylon.js >= 8.5.0.");
+                }
+
                 Write(babylonScene, outputBabylonDirectory, outputFileName, exportParameters.outputFormat, exportParameters.generateManifest);
             }
 

--- a/Maya/Exporter/GlobalVertex.cs
+++ b/Maya/Exporter/GlobalVertex.cs
@@ -18,9 +18,9 @@ namespace MayaBabylon
         public float[] UV6 { get; set; } // Vec2
         public float[] UV7 { get; set; } // Vec2
         public float[] UV8 { get; set; } // Vec2
-        public int[] BonesIndices { get; set; }
+        public ushort[] BonesIndices { get; set; }
         public float[] Weights { get; set; } // Vec4
-        public int[] BonesIndicesExtra { get; set; }
+        public ushort[] BonesIndicesExtra { get; set; }
         public float[] WeightsExtra { get; set; } // Vec4
         public float[] Color { get; set; } // Vec4
 

--- a/Maya/Exporter/GlobalVertex.cs
+++ b/Maya/Exporter/GlobalVertex.cs
@@ -1,4 +1,5 @@
 using Maya2Babylon;
+using System;
 
 namespace MayaBabylon
 {
@@ -17,9 +18,9 @@ namespace MayaBabylon
         public float[] UV6 { get; set; } // Vec2
         public float[] UV7 { get; set; } // Vec2
         public float[] UV8 { get; set; } // Vec2
-        public int BonesIndices { get; set; }
+        public long BonesIndices { get; set; }
         public float[] Weights { get; set; } // Vec4
-        public int BonesIndicesExtra { get; set; }
+        public long BonesIndicesExtra { get; set; }
         public float[] WeightsExtra { get; set; } // Vec4
         public float[] Color { get; set; } // Vec4
 

--- a/Maya/Exporter/GlobalVertex.cs
+++ b/Maya/Exporter/GlobalVertex.cs
@@ -18,9 +18,9 @@ namespace MayaBabylon
         public float[] UV6 { get; set; } // Vec2
         public float[] UV7 { get; set; } // Vec2
         public float[] UV8 { get; set; } // Vec2
-        public long BonesIndices { get; set; }
+        public int[] BonesIndices { get; set; }
         public float[] Weights { get; set; } // Vec4
-        public long BonesIndicesExtra { get; set; }
+        public int[] BonesIndicesExtra { get; set; }
         public float[] WeightsExtra { get; set; } // Vec4
         public float[] Color { get; set; } // Vec4
 

--- a/Maya/Maya2Babylon.sln
+++ b/Maya/Maya2Babylon.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35919.96 d17.13
+VisualStudioVersion = 17.13.35919.96
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Maya2Babylon2017", "Maya2Babylon2017.csproj", "{50780553-6248-463B-A0F3-F82C6CCEC703}"
 EndProject
@@ -69,7 +69,17 @@ Global
 		..\SharedProjects\BabylonFileConverter\BabylonFileConverter.projitems*{074cced5-52d1-4cb3-94d8-b8b117d452e1}*SharedItemsImports = 4
 		..\SharedProjects\GltfExport.Entities\GltfExport.Entities.projitems*{074cced5-52d1-4cb3-94d8-b8b117d452e1}*SharedItemsImports = 4
 		..\SharedProjects\Utilities\Extensions.projitems*{074cced5-52d1-4cb3-94d8-b8b117d452e1}*SharedItemsImports = 4
+		..\SharedProjects\Babylon2GLTF\Babylon2GLTF.projitems*{0ac46a8e-8c0d-4ebe-b64a-4cc274e0ff38}*SharedItemsImports = 4
+		..\SharedProjects\BabylonExport.Entities\BabylonExport.Entities.projitems*{0ac46a8e-8c0d-4ebe-b64a-4cc274e0ff38}*SharedItemsImports = 4
+		..\SharedProjects\BabylonFileConverter\BabylonFileConverter.projitems*{0ac46a8e-8c0d-4ebe-b64a-4cc274e0ff38}*SharedItemsImports = 4
+		..\SharedProjects\GltfExport.Entities\GltfExport.Entities.projitems*{0ac46a8e-8c0d-4ebe-b64a-4cc274e0ff38}*SharedItemsImports = 4
+		..\SharedProjects\Utilities\Extensions.projitems*{0ac46a8e-8c0d-4ebe-b64a-4cc274e0ff38}*SharedItemsImports = 4
 		..\SharedProjects\BabylonExport.Entities\BabylonExport.Entities.projitems*{2a678a75-f8c2-41ba-814a-53e611f5eb96}*SharedItemsImports = 13
+		..\SharedProjects\Babylon2GLTF\Babylon2GLTF.projitems*{50780553-6248-463b-a0f3-f82c6ccec703}*SharedItemsImports = 4
+		..\SharedProjects\BabylonExport.Entities\BabylonExport.Entities.projitems*{50780553-6248-463b-a0f3-f82c6ccec703}*SharedItemsImports = 4
+		..\SharedProjects\BabylonFileConverter\BabylonFileConverter.projitems*{50780553-6248-463b-a0f3-f82c6ccec703}*SharedItemsImports = 4
+		..\SharedProjects\GltfExport.Entities\GltfExport.Entities.projitems*{50780553-6248-463b-a0f3-f82c6ccec703}*SharedItemsImports = 4
+		..\SharedProjects\Utilities\Extensions.projitems*{50780553-6248-463b-a0f3-f82c6ccec703}*SharedItemsImports = 4
 		..\SharedProjects\Babylon2GLTF\Babylon2GLTF.projitems*{63ff7f8b-1802-4990-a252-6caf3d7c406d}*SharedItemsImports = 4
 		..\SharedProjects\BabylonExport.Entities\BabylonExport.Entities.projitems*{63ff7f8b-1802-4990-a252-6caf3d7c406d}*SharedItemsImports = 4
 		..\SharedProjects\BabylonFileConverter\BabylonFileConverter.projitems*{63ff7f8b-1802-4990-a252-6caf3d7c406d}*SharedItemsImports = 4

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -159,22 +159,9 @@ namespace Babylon2GLTF
                 }
                 if (hasBones)
                 {
-                    // In babylon, the 4 bones indices are stored in a single int
-                    // Each bone index is 8-bit offset from the next
-                    ushort[] unpackBabylonBonesToArray (ulong babylonBoneIndices)
-                    {
-                        ulong bone3 = babylonBoneIndices >> 48;
-                        ulong bone2 = (babylonBoneIndices << 16) >> 48;
-                        ulong bone1 = (babylonBoneIndices << 32) >> 48;
-                        ulong bone0 = (babylonBoneIndices << 48) >> 48;
-                        babylonBoneIndices -= bone0 << 0;
-                        return new ushort[] { (ushort)bone0, (ushort)bone1, (ushort)bone2, (ushort)bone3 };
-                    }
-
-                    ulong bonesIndicesMerged = (ulong)meshData.matricesIndices[indexVertex];
-                    globalVertex.BonesIndices = unpackBabylonBonesToArray(bonesIndicesMerged);
+                    globalVertex.BonesIndices = ArrayExtension.SubArrayFromEntity(meshData.matricesIndices, indexVertex, 4); ;
                     globalVertex.BonesWeights = ArrayExtension.SubArrayFromEntity(meshData.matricesWeights, indexVertex, 4);
-                    void clearBoneUnusedIndices(ushort[] indices, float[] weights)
+                    void clearBoneUnusedIndices(int[] indices, float[] weights)
                     {
                         for (int i = 0; i < indices.Length; ++i)
                         {
@@ -190,8 +177,7 @@ namespace Babylon2GLTF
 
                     if (hasBonesExtra)
                     {
-                        ulong bonesIndicesExtraMerged = (ulong)meshData.matricesIndicesExtra[indexVertex];
-                        globalVertex.BonesIndicesExtra = unpackBabylonBonesToArray(bonesIndicesExtraMerged);
+                        globalVertex.BonesIndicesExtra = ArrayExtension.SubArrayFromEntity(meshData.matricesIndicesExtra, indexVertex, 4);
                         globalVertex.BonesWeightsExtra = ArrayExtension.SubArrayFromEntity(meshData.matricesWeightsExtra, indexVertex, 4);
                         
                         clearBoneUnusedIndices(globalVertex.BonesIndicesExtra, globalVertex.BonesWeightsExtra);
@@ -573,7 +559,7 @@ namespace Babylon2GLTF
                             );
                             meshPrimitive.attributes.Add(GLTFMeshPrimitive.Attribute.JOINTS_0.ToString(), accessorJoints.index);
                             // Populate accessor
-                            List<ushort> joints = globalVerticesSubMesh.SelectMany(v => new[] { v.BonesIndices[0], v.BonesIndices[1], v.BonesIndices[2], v.BonesIndices[3] }).ToList();
+                            List<ushort> joints = globalVerticesSubMesh.SelectMany(v => new[] { (ushort)v.BonesIndices[0], (ushort)v.BonesIndices[1], (ushort)v.BonesIndices[2], (ushort)v.BonesIndices[3] }).ToList();
                             joints.ForEach(n => accessorJoints.bytesList.AddRange(BitConverter.GetBytes(n)));
                             accessorJoints.count = globalVerticesSubMesh.Count;
 
@@ -589,7 +575,7 @@ namespace Babylon2GLTF
                                 );
                                 meshPrimitive.attributes.Add(GLTFMeshPrimitive.Attribute.JOINTS_1.ToString(), accessorJointsExtra.index);
                                 // Populate accessor
-                                List<ushort> jointsExtra = globalVerticesSubMesh.SelectMany(v => new[] { v.BonesIndicesExtra[0], v.BonesIndicesExtra[1], v.BonesIndicesExtra[2], v.BonesIndicesExtra[3] }).ToList();
+                                List<ushort> jointsExtra = globalVerticesSubMesh.SelectMany(v => new[] { (ushort)v.BonesIndicesExtra[0], (ushort)v.BonesIndicesExtra[1], (ushort)v.BonesIndicesExtra[2], (ushort)v.BonesIndicesExtra[3] }).ToList();
                                 jointsExtra.ForEach(n => accessorJointsExtra.bytesList.AddRange(BitConverter.GetBytes(n)));
                                 accessorJointsExtra.count = globalVerticesSubMesh.Count;
                             }

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -159,9 +159,10 @@ namespace Babylon2GLTF
                 }
                 if (hasBones)
                 {
-                    globalVertex.BonesIndices = ArrayExtension.SubArrayFromEntity(meshData.matricesIndices, indexVertex, 4); ;
+                    uint[] bonesIndices = ArrayExtension.SubArrayFromEntity(meshData.matricesIndices, indexVertex, 4); ;
+                    globalVertex.BonesIndices = bonesIndices.Select(a => (ushort)a).ToArray();
                     globalVertex.BonesWeights = ArrayExtension.SubArrayFromEntity(meshData.matricesWeights, indexVertex, 4);
-                    void clearBoneUnusedIndices(int[] indices, float[] weights)
+                    void clearBoneUnusedIndices(ushort[] indices, float[] weights)
                     {
                         for (int i = 0; i < indices.Length; ++i)
                         {
@@ -177,7 +178,8 @@ namespace Babylon2GLTF
 
                     if (hasBonesExtra)
                     {
-                        globalVertex.BonesIndicesExtra = ArrayExtension.SubArrayFromEntity(meshData.matricesIndicesExtra, indexVertex, 4);
+                        uint[] bonesIndicesExtra = ArrayExtension.SubArrayFromEntity(meshData.matricesIndicesExtra, indexVertex, 4);
+                        globalVertex.BonesIndicesExtra = bonesIndicesExtra.Select(a => (ushort)a).ToArray();
                         globalVertex.BonesWeightsExtra = ArrayExtension.SubArrayFromEntity(meshData.matricesWeightsExtra, indexVertex, 4);
                         
                         clearBoneUnusedIndices(globalVertex.BonesIndicesExtra, globalVertex.BonesWeightsExtra);

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Mesh.cs
@@ -161,17 +161,17 @@ namespace Babylon2GLTF
                 {
                     // In babylon, the 4 bones indices are stored in a single int
                     // Each bone index is 8-bit offset from the next
-                    ushort[] unpackBabylonBonesToArray (uint babylonBoneIndices)
+                    ushort[] unpackBabylonBonesToArray (ulong babylonBoneIndices)
                     {
-                        uint bone3 = babylonBoneIndices >> 24;
-                        uint bone2 = (babylonBoneIndices << 8) >> 24;
-                        uint bone1 = (babylonBoneIndices << 16) >> 24;
-                        uint bone0 = (babylonBoneIndices << 24) >> 24;
+                        ulong bone3 = babylonBoneIndices >> 48;
+                        ulong bone2 = (babylonBoneIndices << 16) >> 48;
+                        ulong bone1 = (babylonBoneIndices << 32) >> 48;
+                        ulong bone0 = (babylonBoneIndices << 48) >> 48;
                         babylonBoneIndices -= bone0 << 0;
                         return new ushort[] { (ushort)bone0, (ushort)bone1, (ushort)bone2, (ushort)bone3 };
                     }
 
-                    uint bonesIndicesMerged = (uint)meshData.matricesIndices[indexVertex];
+                    ulong bonesIndicesMerged = (ulong)meshData.matricesIndices[indexVertex];
                     globalVertex.BonesIndices = unpackBabylonBonesToArray(bonesIndicesMerged);
                     globalVertex.BonesWeights = ArrayExtension.SubArrayFromEntity(meshData.matricesWeights, indexVertex, 4);
                     void clearBoneUnusedIndices(ushort[] indices, float[] weights)
@@ -190,7 +190,7 @@ namespace Babylon2GLTF
 
                     if (hasBonesExtra)
                     {
-                        uint bonesIndicesExtraMerged = (uint)meshData.matricesIndicesExtra[indexVertex];
+                        ulong bonesIndicesExtraMerged = (ulong)meshData.matricesIndicesExtra[indexVertex];
                         globalVertex.BonesIndicesExtra = unpackBabylonBonesToArray(bonesIndicesExtraMerged);
                         globalVertex.BonesWeightsExtra = ArrayExtension.SubArrayFromEntity(meshData.matricesWeightsExtra, indexVertex, 4);
                         

--- a/SharedProjects/Babylon2GLTF/GLTFGlobalVertex.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFGlobalVertex.cs
@@ -16,8 +16,8 @@ namespace GLTFExport.Entities
         public BabylonVector2 UV7 { get; set; }
         public BabylonVector2 UV8 { get; set; }
         public float[] Color { get; set; }
-        public ushort[] BonesIndices { get; set; }
-        public ushort[] BonesIndicesExtra { get; set; }
+        public int[] BonesIndices { get; set; }
+        public int[] BonesIndicesExtra { get; set; }
         public float[] BonesWeights { get; set; }
         public float[] BonesWeightsExtra { get; set; }
     }

--- a/SharedProjects/Babylon2GLTF/GLTFGlobalVertex.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFGlobalVertex.cs
@@ -16,8 +16,8 @@ namespace GLTFExport.Entities
         public BabylonVector2 UV7 { get; set; }
         public BabylonVector2 UV8 { get; set; }
         public float[] Color { get; set; }
-        public int[] BonesIndices { get; set; }
-        public int[] BonesIndicesExtra { get; set; }
+        public ushort[] BonesIndices { get; set; }
+        public ushort[] BonesIndicesExtra { get; set; }
         public float[] BonesWeights { get; set; }
         public float[] BonesWeightsExtra { get; set; }
     }

--- a/SharedProjects/BabylonExport.Entities/BabylonMesh.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMesh.cs
@@ -19,8 +19,8 @@ namespace BabylonExport.Entities
         float[] uvs7 { get; set; }
         float[] uvs8 { get; set; }
         float[] colors { get; set; }
-        int[] matricesIndices { get; set; }
-        int[] matricesIndicesExtra { get; set; }
+        long[] matricesIndices { get; set; }
+        long[] matricesIndicesExtra { get; set; }
         float[] matricesWeights { get; set; }
         float[] matricesWeightsExtra { get; set; }
         int[] indices { get; set; }
@@ -84,13 +84,13 @@ namespace BabylonExport.Entities
         public bool hasVertexAlpha { get; set; }
 
         [DataMember]
-        public int[] matricesIndices { get; set; }
+        public long[] matricesIndices { get; set; }
 
         [DataMember]
         public float[] matricesWeights { get; set; }
 
         [DataMember]
-        public int[] matricesIndicesExtra { get; set; }
+        public long[] matricesIndicesExtra { get; set; }
 
         [DataMember]
         public float[] matricesWeightsExtra { get; set; }

--- a/SharedProjects/BabylonExport.Entities/BabylonMesh.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMesh.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
+
 namespace BabylonExport.Entities
 {
     public interface IBabylonMeshData
@@ -19,11 +20,13 @@ namespace BabylonExport.Entities
         float[] uvs7 { get; set; }
         float[] uvs8 { get; set; }
         float[] colors { get; set; }
-        long[] matricesIndices { get; set; }
-        long[] matricesIndicesExtra { get; set; }
+        int[] matricesIndices { get; set; }
+        int[] matricesIndicesExtra { get; set; }
         float[] matricesWeights { get; set; }
         float[] matricesWeightsExtra { get; set; }
         int[] indices { get; set; }
+
+        bool TryPackIndexArrays();
     }
 
     [DataContract]
@@ -84,13 +87,13 @@ namespace BabylonExport.Entities
         public bool hasVertexAlpha { get; set; }
 
         [DataMember]
-        public long[] matricesIndices { get; set; }
+        public int[] matricesIndices { get; set; }
 
         [DataMember]
         public float[] matricesWeights { get; set; }
 
         [DataMember]
-        public long[] matricesIndicesExtra { get; set; }
+        public int[] matricesIndicesExtra { get; set; }
 
         [DataMember]
         public float[] matricesWeightsExtra { get; set; }
@@ -137,6 +140,12 @@ namespace BabylonExport.Entities
         [DataMember]
         public float[] lodCoverages { get; set; }
 
+        [DataMember]
+        public bool matricesIndicesExpanded { get; set; }
+
+        [DataMember]
+        public bool matricesIndicesExtraExpanded { get; set; }
+
         public bool isDummy = false;
 
         public List<VertexData> VertexDatas { get; set; } = new List<VertexData>();
@@ -145,6 +154,8 @@ namespace BabylonExport.Entities
         {
             isEnabled = true;
             isVisible = true;
+            matricesIndicesExpanded = false;
+            matricesIndicesExtraExpanded = false;
 
             billboardMode = 0;
 
@@ -178,6 +189,56 @@ namespace BabylonExport.Entities
             // finally, compare the skinning matrix weights within a tolerance threshold.
             var skinDifference = babylonMesh.matricesWeights.Zip(matchingSkinnedMesh.matricesWeights, (first, second) => first - second).ToArray();
             return skinDifference.All(value => Math.Abs(value) < BabylonMesh.SkinningWeightToleranceThreshold);
+        }
+
+        private int[] CreatePackedArray(int[] rawArray)
+        {
+            var arrayReplacement = new int[rawArray.Length / 4];
+
+            for (int i = 0; i < arrayReplacement.Length; i++)
+            {
+                int rawIndex = i * 4;
+                int bone0 = rawArray[rawIndex];
+                int bone1 = rawArray[rawIndex + 1];
+                int bone2 = rawArray[rawIndex + 2];
+                int bone3 = rawArray[rawIndex + 3];
+                arrayReplacement[i] = (bone3 << 24) | (bone2 << 16) | (bone1 << 8) | bone0;
+            }
+
+            return arrayReplacement;
+        }
+
+        public bool TryPackIndexArrays()
+        {
+            bool result = true;
+
+            if (matricesIndices != null && matricesIndices.Length != 0)
+            {
+                if (matricesIndices != null && matricesIndices.Any(a => a > 255))
+                {
+                    matricesIndicesExpanded = true;
+                    result = false;
+                }
+                else
+                {
+                    matricesIndices = CreatePackedArray(matricesIndices);
+                }
+            }
+
+            if (matricesIndicesExtra != null && matricesIndicesExtra.Length != 0)
+            {
+                if (matricesIndicesExtra != null && matricesIndicesExtra.Any(a => a > 255))
+                {
+                    matricesIndicesExtraExpanded = true;
+                    result = false;
+                }
+                else
+                {
+                    matricesIndicesExtra = CreatePackedArray(matricesIndicesExtra);
+                }
+            }
+
+            return result;
         }
     }
 

--- a/SharedProjects/BabylonExport.Entities/BabylonMesh.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonMesh.cs
@@ -20,8 +20,8 @@ namespace BabylonExport.Entities
         float[] uvs7 { get; set; }
         float[] uvs8 { get; set; }
         float[] colors { get; set; }
-        int[] matricesIndices { get; set; }
-        int[] matricesIndicesExtra { get; set; }
+        uint[] matricesIndices { get; set; }
+        uint[] matricesIndicesExtra { get; set; }
         float[] matricesWeights { get; set; }
         float[] matricesWeightsExtra { get; set; }
         int[] indices { get; set; }
@@ -87,13 +87,13 @@ namespace BabylonExport.Entities
         public bool hasVertexAlpha { get; set; }
 
         [DataMember]
-        public int[] matricesIndices { get; set; }
+        public uint[] matricesIndices { get; set; }
 
         [DataMember]
         public float[] matricesWeights { get; set; }
 
         [DataMember]
-        public int[] matricesIndicesExtra { get; set; }
+        public uint[] matricesIndicesExtra { get; set; }
 
         [DataMember]
         public float[] matricesWeightsExtra { get; set; }
@@ -191,17 +191,17 @@ namespace BabylonExport.Entities
             return skinDifference.All(value => Math.Abs(value) < BabylonMesh.SkinningWeightToleranceThreshold);
         }
 
-        private int[] CreatePackedArray(int[] rawArray)
+        private uint[] CreatePackedArray(uint[] rawArray)
         {
-            var arrayReplacement = new int[rawArray.Length / 4];
+            var arrayReplacement = new uint[rawArray.Length / 4];
 
             for (int i = 0; i < arrayReplacement.Length; i++)
             {
                 int rawIndex = i * 4;
-                int bone0 = rawArray[rawIndex];
-                int bone1 = rawArray[rawIndex + 1];
-                int bone2 = rawArray[rawIndex + 2];
-                int bone3 = rawArray[rawIndex + 3];
+                uint bone0 = rawArray[rawIndex];
+                uint bone1 = rawArray[rawIndex + 1];
+                uint bone2 = rawArray[rawIndex + 2];
+                uint bone3 = rawArray[rawIndex + 3];
                 arrayReplacement[i] = (bone3 << 24) | (bone2 << 16) | (bone1 << 8) | bone0;
             }
 

--- a/SharedProjects/BabylonExport.Entities/BabylonScene.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonScene.cs
@@ -218,5 +218,17 @@ namespace BabylonExport.Entities
                 animationGroups = null;
             }
         }
+
+        internal bool PackIndexArrays()
+        {
+            bool result = true;
+
+            foreach (var mesh  in meshes)
+            {
+                result &= mesh.TryPackIndexArrays();
+            }
+
+            return result;
+        }
     }
 }

--- a/SharedProjects/BabylonExport.Entities/BabylonScene.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonScene.cs
@@ -219,7 +219,7 @@ namespace BabylonExport.Entities
             }
         }
 
-        internal bool PackIndexArrays()
+        internal bool TryPackIndexArrays()
         {
             bool result = true;
 

--- a/SharedProjects/BabylonExport.Entities/BabylonVertexData.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonVertexData.cs
@@ -53,10 +53,10 @@ namespace BabylonExport.Entities
         public float[] colors { get; set; }
 
         [DataMember]
-        public int[] matricesIndices { get; set; }
+        public long[] matricesIndices { get; set; }
 
         [DataMember]
-        public int[] matricesIndicesExtra { get; set; }
+        public long[] matricesIndicesExtra { get; set; }
 
         [DataMember]
         public float[] matricesWeights { get; set; }

--- a/SharedProjects/BabylonExport.Entities/BabylonVertexData.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonVertexData.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Linq;
+using System.Runtime.Serialization;
 
 namespace BabylonExport.Entities
 {
@@ -53,10 +54,10 @@ namespace BabylonExport.Entities
         public float[] colors { get; set; }
 
         [DataMember]
-        public long[] matricesIndices { get; set; }
+        public int[] matricesIndices { get; set; }
 
         [DataMember]
-        public long[] matricesIndicesExtra { get; set; }
+        public int[] matricesIndicesExtra { get; set; }
 
         [DataMember]
         public float[] matricesWeights { get; set; }
@@ -66,6 +67,13 @@ namespace BabylonExport.Entities
 
         [DataMember]
         public int[] indices { get; set; }
+
+        [DataMember]
+        public bool matricesIndicesExpanded { get; set; }
+
+        [DataMember]
+        public bool matricesIndicesExtraExpanded { get; set; }
+
         #endregion
 
         public BabylonVertexData() { }
@@ -94,6 +102,58 @@ namespace BabylonExport.Entities
             matricesWeights = data.matricesWeights;
             matricesWeightsExtra = data.matricesWeightsExtra;
             indices = data.indices;
+            matricesIndicesExpanded = false;
+            matricesIndicesExtraExpanded = false;
+        }
+
+        private int[] CreatePackedArray(int[] rawArray)
+        {
+            var arrayReplacement = new int[rawArray.Length / 4];
+
+            for (int i = 0; i < arrayReplacement.Length; i++)
+            {
+                int rawIndex = i * 4;
+                int bone0 = rawArray[rawIndex];
+                int bone1 = rawArray[rawIndex + 1];
+                int bone2 = rawArray[rawIndex + 2];
+                int bone3 = rawArray[rawIndex + 3];
+                arrayReplacement[i] = (bone3 << 24) | (bone2 << 16) | (bone1 << 8) | bone0;
+            }
+
+            return arrayReplacement;
+        }
+
+        public bool TryPackIndexArrays()
+        {
+            bool result = true;
+
+            if (matricesIndices != null && matricesIndices.Length != 0)
+            {
+                if (matricesIndices != null && matricesIndices.Any(a => a > 255))
+                {
+                    matricesIndicesExpanded = true;
+                    result = false;
+                }
+                else
+                {
+                    matricesIndices = CreatePackedArray(matricesIndices);
+                }
+            }
+
+            if (matricesIndicesExtra != null && matricesIndicesExtra.Length != 0)
+            {
+                if (matricesIndicesExtra != null && matricesIndicesExtra.Any(a => a > 255))
+                {
+                    matricesIndicesExtraExpanded = true;
+                    result = false;
+                }
+                else
+                {
+                    matricesIndicesExtra = CreatePackedArray(matricesIndicesExtra);
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/SharedProjects/BabylonExport.Entities/BabylonVertexData.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonVertexData.cs
@@ -54,10 +54,10 @@ namespace BabylonExport.Entities
         public float[] colors { get; set; }
 
         [DataMember]
-        public int[] matricesIndices { get; set; }
+        public uint[] matricesIndices { get; set; }
 
         [DataMember]
-        public int[] matricesIndicesExtra { get; set; }
+        public uint[] matricesIndicesExtra { get; set; }
 
         [DataMember]
         public float[] matricesWeights { get; set; }
@@ -106,17 +106,17 @@ namespace BabylonExport.Entities
             matricesIndicesExtraExpanded = false;
         }
 
-        private int[] CreatePackedArray(int[] rawArray)
+        private uint[] CreatePackedArray(uint[] rawArray)
         {
-            var arrayReplacement = new int[rawArray.Length / 4];
+            var arrayReplacement = new uint[rawArray.Length / 4];
 
             for (int i = 0; i < arrayReplacement.Length; i++)
             {
                 int rawIndex = i * 4;
-                int bone0 = rawArray[rawIndex];
-                int bone1 = rawArray[rawIndex + 1];
-                int bone2 = rawArray[rawIndex + 2];
-                int bone3 = rawArray[rawIndex + 3];
+                uint bone0 = rawArray[rawIndex];
+                uint bone1 = rawArray[rawIndex + 1];
+                uint bone2 = rawArray[rawIndex + 2];
+                uint bone3 = rawArray[rawIndex + 3];
                 arrayReplacement[i] = (bone3 << 24) | (bone2 << 16) | (bone1 << 8) | bone0;
             }
 


### PR DESCRIPTION
GLTF allows bone indexes to be stored as 16 bit values, in our implementation we use a 32 bit integer to store 4 bones as bytes, this breaks the exporter for models that have more than 256 bones  even though they would be able to fit into a GLTF. I'm increasing our internal store of the bones to be done using 64bit integer to allow bones to be hold using 16bit, matching what is expected by GLTF. 