### PR TITLE
Add ability to set useAlphaFromDiffuseTexture from UI

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.Material.cs
@@ -123,6 +123,7 @@ namespace Max2Babylon
         public const string EnvironmentIntensityStr = "babylonEnvironmentIntensity";
         public const string SpecularIntensityStr = "babylonSpecularIntensity";
         public const string TransparencyModeStr = "babylonTransparencyMode";
+        public const string UseAlphaFromDiffuseTextureStr = "babylonUseAlphaFromDiffuseTexture";
 
         public static IEnumerable<string> ListPrivatePropertyNames()
         {
@@ -135,6 +136,7 @@ namespace Max2Babylon
             yield return EnvironmentIntensityStr;
             yield return SpecularIntensityStr;
             yield return TransparencyModeStr;
+            yield return UseAlphaFromDiffuseTextureStr;
         }
 
         public BabylonCustomAttributeDecorator(IIGameMaterial node) : base(node)
@@ -151,6 +153,7 @@ namespace Max2Babylon
         public float EnvironementIntensity => Properties?.GetFloatProperty(EnvironmentIntensityStr, 1.0f) ?? 1.0f;
         public float SpecularIntensity => Properties?.GetFloatProperty(SpecularIntensityStr, 1.0f) ?? 1.0f;
         public int TransparencyMode => Properties?.GetIntProperty(TransparencyModeStr, 0) ?? 0;
+        public bool UseAlphaFromDiffuseTexture => Properties?.GetBoolProperty(UseAlphaFromDiffuseTextureStr, false) ?? false;
     }
 
     /// <summary>
@@ -337,6 +340,7 @@ namespace Max2Babylon
         private void ExportStandardMaterial(IIGameMaterial materialNode, IIPropertyContainer attributesContainer, IStdMat2 stdMat, BabylonScene babylonScene, BabylonStandardMaterial babylonMaterial)
         {
             bool isTransparencyModeFromBabylonAttributes = false;
+            bool useAlphaFromDiffuseTexture = false;
             if (attributesContainer != null)
             {
                 IIGameProperty babylonTransparencyModeGameProperty = attributesContainer.QueryProperty("babylonTransparencyMode");
@@ -345,7 +349,15 @@ namespace Max2Babylon
                     babylonMaterial.transparencyMode = babylonTransparencyModeGameProperty.GetIntValue();
                     isTransparencyModeFromBabylonAttributes = true;
                 }
+
+                IIGameProperty babylonUseAlphaFromDiffuseTextureGameProperty = attributesContainer.QueryProperty("babylonUseAlphaFromDiffuseTexture");
+                if (babylonUseAlphaFromDiffuseTextureGameProperty != null)
+                {
+                    useAlphaFromDiffuseTexture = babylonUseAlphaFromDiffuseTextureGameProperty.GetBoolValue();
+                }
             }
+
+            babylonMaterial.useAlphaFromDiffuseTexture = useAlphaFromDiffuseTexture;
 
             if (isTransparencyModeFromBabylonAttributes == false || babylonMaterial.transparencyMode != 0)
             {
@@ -548,6 +560,7 @@ namespace Max2Babylon
             excludeAttributes.Add("babylonUnlit");
             excludeAttributes.Add("babylonMaxSimultaneousLights");
             excludeAttributes.Add("babylonTransparencyMode");
+            excludeAttributes.Add("babylonUseAlphaFromDiffuseTexture");
 
             // Export the custom attributes of this material
             babylonMaterial.metadata = ExportExtraAttributes(materialNode, babylonScene, excludeAttributes);

--- a/3ds Max/Max2Babylon/Scripts/STANDARD_MATERIAL_CAT_DEF.ms
+++ b/3ds Max/Max2Babylon/Scripts/STANDARD_MATERIAL_CAT_DEF.ms
@@ -9,6 +9,7 @@ version:2
     parameters main rollout:params
     (
         babylonUnlit type:#boolean ui:babylonUnlit_ui
+        babylonUseAlphaFromDiffuseTexture type:#boolean ui:babylonUseAlphaFromDiffuseTexture_ui
         babylonMaxSimultaneousLights type:#integer ui:babylonMaxSimultaneousLights_ui default:4
         babylonTransparencyMode type:#integer default:0
     )
@@ -20,5 +21,6 @@ version:2
         label babylonTransparencyMode_label "Transparency Mode " Align: #Left across:2
         dropdownlist babylonTransparencyMode_dd  items:# ("Opaque","Cutoff","Blend") selection:(babylonTransparencyMode+1) Align: #Right
         on babylonTransparencyMode_dd selected i do babylonTransparencyMode = i-1
-    )    
+        checkbox babylonUseAlphaFromDiffuseTexture_ui "Use alpha from diffuse texture" Align: #Left across:3
+    )
 )

--- a/SharedProjects/BabylonExport.Entities/BabylonStandardMaterial.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonStandardMaterial.cs
@@ -77,6 +77,9 @@ namespace BabylonExport.Entities
         [DataMember]
         public bool useGlossinessFromSpecularMapAlpha { get; set; }
 
+        [DataMember]
+        public bool useAlphaFromDiffuseTexture { get; set; }
+
         [DataMember(EmitDefaultValue = false)]
         public float? alphaCutOff { get; set; }
 


### PR DESCRIPTION
<img width="726" height="764" alt="image" src="https://github.com/user-attachments/assets/3401a6eb-4829-4965-aad5-8bfe2e306bfa" />

Pretty much self-explanatory. Another approach would be to set it conditionally, like useAlphaFromAlbedoTexture, but I don’t feel like introducing a breaking change into a project that's in maintenance mode :) It doesn’t take up much space in the UI and might be useful for someone - in fact, it’s already beneficial for our team