### PR TITLE
Fixed bug when copying base PBR material, missing sheen

### DIFF
--- a/SharedProjects/BabylonExport.Entities/BabylonPBRBaseSimpleMaterial.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonPBRBaseSimpleMaterial.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.Serialization;
-using System.Windows.Forms;
 
 namespace BabylonExport.Entities
 {


### PR DESCRIPTION
When creating a new BabylonPBRBaseSimpleMaterial from a previews one we forget to copy sheen value. This can cause NullReference exceptions during export since exporter assumes the sheen property will always be set. 